### PR TITLE
Add Always On on Replit

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 require("dotenv").config();//Loading .env
+const keepAlive = require('./server');
 const fs = require("fs");
 const { Collection, Client } = require("discord.js");
 
@@ -34,4 +35,5 @@ fs.readdir("./commands/", (err, files) => {
 });
 
 //Logging in to discord
+keepAlive();
 client.login(process.env.TOKEN)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@discordjs/opus": "^0.3.2",
     "discord.js": "^12.3.1",
     "dotenv": "^8.2.0",
+    "express": "^4.17.1",
     "ffmpeg": "0.0.4",
     "ffmpeg-static": "^4.2.7",
     "yt-search": "^2.2.4",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const server = express();
+server.all('/', (req, res)=>{
+    res.send('Your bot is alive!')
+})
+function keepAlive(){
+    server.listen(8080, ()=>{console.log("Server is Ready!")});
+}
+module.exports = keepAlive;


### PR DESCRIPTION
Get the Repl Url
Create a Account on Uptimerobot
Insert the URL as HTTP
Your Bot stays on forever

Source: https://repl.it/talk/learn/Hosting-discordjs-bots-on-replit-Works-for-both-discordjs-and-Eris/11027
Issue: https://github.com/SudhanPlayz/Discord-MusicBot/issues/74