### PR TITLE
fix this one silly bug

### DIFF
--- a/commands/help.js
+++ b/commands/help.js
@@ -13,7 +13,7 @@ module.exports = {
 
         client.commands.forEach(cmd => {
             let cmdinfo = cmd.info
-            allcmds+="``"+client.config.prefix+cmdinfo.name+" "+cmdinfo.usage+"`` ~ "+cmdinfo.description+"\n"
+            allcmds+="`"+client.config.prefix+cmdinfo.name+" "+cmdinfo.usage+"` ~ "+cmdinfo.description+"\n"
         })
 
         let embed = new MessageEmbed()


### PR DESCRIPTION
For this issue SudhanPlayz/Discord-MusicBot#84

edit: If you want to display special characters, just add backslash (`\`) before that. Example: \\` will display the actual symbol instead of forming a codeblock decoration.