### PR TITLE
Update search.js

### DIFF
--- a/commands/search.js
+++ b/commands/search.js
@@ -5,7 +5,7 @@ const prettyMilliseconds = require("pretty-ms");
 
 module.exports = {
     name: "search",
-    description: "Search a song/playlist",
+    description: "Search a song or playlist",
     usage: "[Song Name|SongURL]",
     permissions: {
         channel: ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS"],


### PR DESCRIPTION
Using special character causes a DiscordAPIError: Invalid Form Body for slash commands. 

Error:
```
DiscordAPIError: Invalid Form Body
options[0].name: String value did not match validation regex.
```

This fixes the issue by  removing the special character.