### PR TITLE
Fixed display of queued song counter

### DIFF
--- a/views/server.html
+++ b/views/server.html
@@ -328,6 +328,7 @@
       socket.emit("server", window.location.pathname.split("/")[2]);
 
       socket.on("server", (data) => {
+        $("#songInQueue").text(data.queue);
         $("#songLoop").text(data.songsLoop);
         $("#queueLoop").text(data.queueLoop);
         $("#prefix").text(data.prefix);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Currently the queue counter on the server / guild status page does not get updated.
I added the code to update this counter with the incoming status updates


**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
