### PR TITLE
Added system for pausing the player when nobody is listening

### DIFF
--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -1,0 +1,53 @@
+const { DiscordMusicBot } = require('../structures/DiscordMusicBot');
+const { VoiceState } = require("discord.js");
+/**
+ *
+ * @param {DiscordMusicBot} client
+ * @param {VoiceState} oldState
+ * @param {VoiceState} newState
+ * @returns {Promise<void>}
+ */
+module.exports = async (client, oldState, newState) => {
+    // skip bot users
+    if (newState.member.user.bot) return;
+
+    // get guild and player
+    let guildId = newState.guild.id;
+    const player = client.Manager.get(guildId);
+
+    // check if the bot is active (playing, paused or empty does not matter (return otherwise)
+    if (!player || player.state !== "CONNECTED") return;
+
+    // prepreoces the data
+    const stateChange = {};
+    // get the state change
+    if (oldState.channel === null && newState.channel !== null) stateChange.type = "JOIN";
+    if (oldState.channel !== null && newState.channel === null) stateChange.type = "LEAVE";
+    if (oldState.channel !== null && newState.channel !== null) stateChange.type = "MOVE";
+    if (oldState.channel === null && newState.channel === null) return; // you never know, right
+
+    // move check first as it changes type
+    if (stateChange.type === "MOVE") {
+        if (oldState.channel.id === player.voiceChannel) stateChange.type = "LEAVE";
+        if (newState.channel.id === player.voiceChannel) stateChange.type = "JOIN";
+    }
+    // double triggered on purpose for MOVE events
+    if (stateChange.type === "JOIN") stateChange.channel = newState.channel;
+    if (stateChange.type === "LEAVE") stateChange.channel = oldState.channel;
+
+    // check if the bot's voice channel is involved (return otherwise)
+    if (!stateChange.channel || stateChange.channel.id !== player.voiceChannel) return;
+
+    switch (stateChange.type) {
+        case "JOIN":
+            if (stateChange.channel.members.size === 2 && player.paused) {
+                player.pause(false);
+            }
+            break;
+        case "LEAVE":
+            if (stateChange.channel.members.size === 1 && !player.paused && player.playing) {
+                player.pause(true);
+            }
+            break;
+    }
+}


### PR DESCRIPTION
Added system for pausing the player when nobody is listening (e.g. everyone left the channel)
This also unpauses the player when someone joins again.
It is using a new event listener to achieve this

sorry for the previous PR, github did not play so nice with me trying to rebase instead of doing merges.
Apparently github does not honor its own repo settings if you disallow merges and try and fetch / merge from upstream (messing up my whole branch)