### PR TITLE
Fixed nowplaying message deletion error when already deleted

### DIFF
--- a/structures/EpicPlayer.js
+++ b/structures/EpicPlayer.js
@@ -10,7 +10,7 @@ Structure.extend(
        * @param {Message} message
        */
       setNowplayingMessage(message) {
-        if (this.nowPlayingMessage) this.nowPlayingMessage.delete();
+        if (this.nowPlayingMessage && !this.nowPlayingMessage.deleted) this.nowPlayingMessage.delete();
         return (this.nowPlayingMessage = message);
       }
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixed the possible error that comes up when `player.setNowplaying()` is run and it tries to remove the now playing message when it is already removed (externally).
Added the check to only delete if it is not yet deleted.


**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
