### PR TITLE
Fixed Total Number Of Users

### DIFF
--- a/commands/stats.js
+++ b/commands/stats.js
@@ -52,7 +52,8 @@ module.exports = {
             },
             {
                 name: ':busts_in_silhouette: Users',
-                value: `┕\`${client.users.cache.size}\``,
+                value: `┕\`${client.guilds.cache.reduce(
+    (prev, guild) => prev + guild.memberCount, 0)}\``,
                 inline: true
             },{
                 name: ':control_knobs: API Latency',
@@ -117,7 +118,8 @@ SlashCommand: {
         },
         {
             name: ':busts_in_silhouette: Users',
-            value: `┕\`${client.users.cache.size}\``,
+            value: `┕\`${client.guilds.cache.reduce(
+    (prev, guild) => prev + guild.memberCount, 0)}\``,
             inline: true
         },{
             name: ':control_knobs: API Latency',


### PR DESCRIPTION
client.guilds.cache.reduce((prev, guild) => prev + guild.memberCount, 0) displays the exact number of users for the bot. It is more accurate than client.users.cache.size.

**Please describe the changes this PR makes and why it should be merged:**



**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
