### PR TITLE
Ability to increast the retryamount for lavalink

### DIFF
--- a/botconfig.js
+++ b/botconfig.js
@@ -23,7 +23,9 @@ module.exports = {
     host: "(host name or IP)",
     port: (port),
     pass: "(password)", 
-    secure: false, // Set this to true if you're self-hosting lavalink on replit.
+    secure: false, // Set this to true if you're hosting your own lavalink on replit and/or using SSL.
+    retrydelay: 15000, // Delay for reconnect in ms.
+    retryamount: 10000000, // Retry amout if the lavalink is dead and/or restarting.
   },
 
 

--- a/botconfig.js
+++ b/botconfig.js
@@ -24,8 +24,8 @@ module.exports = {
     port: (port),
     pass: "(password)", 
     secure: false, // Set this to true if you're hosting your own lavalink on replit and/or using SSL.
-    retrydelay: 15000, // Delay for reconnect in ms.
-    retryamount: 10000000, // Retry amout if the lavalink is dead and/or restarting.
+    retryDelay: 15000, // Delay for reconnect in ms.
+    retryAmount: 10000000, // Retry amount if the lavalink is dead and/or restarting.
   },
 
 

--- a/structures/DiscordMusicBot.js
+++ b/structures/DiscordMusicBot.js
@@ -125,6 +125,8 @@ class DiscordMusicBot extends Client {
           port: this.botconfig.Lavalink.port,
           password: this.botconfig.Lavalink.pass,
           secure: this.botconfig.Lavalink.secure,
+          retryDelay: this.botconfig.Lavalink.retrydelay,
+          retryAmount: this.botconfig.Lavalink.retryamount,
         },
       ]
     );
@@ -137,6 +139,8 @@ class DiscordMusicBot extends Client {
           port: this.botconfig.Lavalink.port,
           password: this.botconfig.Lavalink.pass,
           secure: this.botconfig.Lavalink.secure,
+          retryDelay: this.botconfig.Lavalink.retrydelay,
+          retryAmount: this.botconfig.Lavalink.retryamount,
         },
       ],
       send(id, payload) {

--- a/structures/DiscordMusicBot.js
+++ b/structures/DiscordMusicBot.js
@@ -125,8 +125,8 @@ class DiscordMusicBot extends Client {
           port: this.botconfig.Lavalink.port,
           password: this.botconfig.Lavalink.pass,
           secure: this.botconfig.Lavalink.secure,
-          retryDelay: this.botconfig.Lavalink.retrydelay,
-          retryAmount: this.botconfig.Lavalink.retryamount,
+          retryDelay: this.botconfig.Lavalink.retryDelay,
+          retryAmount: this.botconfig.Lavalink.retryAmount,
         },
       ]
     );
@@ -139,8 +139,8 @@ class DiscordMusicBot extends Client {
           port: this.botconfig.Lavalink.port,
           password: this.botconfig.Lavalink.pass,
           secure: this.botconfig.Lavalink.secure,
-          retryDelay: this.botconfig.Lavalink.retrydelay,
-          retryAmount: this.botconfig.Lavalink.retryamount,
+          retryDelay: this.botconfig.Lavalink.retryDelay,
+          retryAmount: this.botconfig.Lavalink.retryAmount,
         },
       ],
       send(id, payload) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This pr add a way so that if the lavalink restart it auto reconnects and add upto unlimited reconnect retry amount.
New pr cause the old one doesn't detect the new commits


**Status and versioning classification:**