### PR TITLE
Fix scopes for dashboard

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -35,7 +35,7 @@ passport.use(
       clientID: config.ClientID,
       clientSecret: config.ClientSecret,
       callbackURL: config.Website + config.CallbackURL,
-      scope: config.Scopes.join(" "),
+      scope: "identify guilds",
     },
     function (accessToken, refreshToken, profile, done) {
       //User logged in yay!


### PR DESCRIPTION
You don’t need to select server when you wanna go to the “dashboard”.
Suggestion from the discord server.

**Status and versioning classification:**

Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
