### PR TITLE
Bot automatically destroys player when kicked.

### DIFF
--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -1,5 +1,5 @@
-const { DiscordMusicBot } = require('../structures/DiscordMusicBot');
-const { VoiceState, MessageEmbed} = require("discord.js");
+const { DiscordMusicBot } = require("../structures/DiscordMusicBot");
+const { VoiceState, MessageEmbed } = require("discord.js");
 /**
  *
  * @param {DiscordMusicBot} client
@@ -8,65 +8,84 @@ const { VoiceState, MessageEmbed} = require("discord.js");
  * @returns {Promise<void>}
  */
 module.exports = async (client, oldState, newState) => {
-    // skip bot users, just like the message event
-    if (newState.member.user.bot) return;
 
-    // get guild and player
-    let guildId = newState.guild.id;
-    const player = client.Manager.get(guildId);
+  // get guild and player
+  let guildId = newState.guild.id;
+  const player = client.Manager.get(guildId);
 
-    // check if the bot is active (playing, paused or empty does not matter (return otherwise)
-    if (!player || player.state !== "CONNECTED") return;
+  // check if the bot is active (playing, paused or empty does not matter (return otherwise)
+  if (!player || player.state !== "CONNECTED") return;
 
-    // prepreoces the data
-    const stateChange = {};
-    // get the state change
-    if (oldState.channel === null && newState.channel !== null) stateChange.type = "JOIN";
-    if (oldState.channel !== null && newState.channel === null) stateChange.type = "LEAVE";
-    if (oldState.channel !== null && newState.channel !== null) stateChange.type = "MOVE";
-    if (oldState.channel === null && newState.channel === null) return; // you never know, right
+  // prepreoces the data
+  const stateChange = {};
+  // get the state change
+  if (!oldState.channel && newState.channel)
+    stateChange.type = "JOIN";
+  if (oldState.channel && !newState.channel)
+    stateChange.type = "LEAVE";
+  if (oldState.channel && newState.channel)
+    stateChange.type = "MOVE";
+  if (oldState.channel === null && newState.channel === null) return; // you never know, right
+  if (newState.serverMute == true && oldState.serverMute == false)
+    return player.pause(true);
+  if (newState.serverMute == false && oldState.serverMute == true)
+    return player.pause(false);
+  // move check first as it changes type
+  if (stateChange.type === "MOVE") {
+    if (oldState.channel.id === player.voiceChannel) stateChange.type = "LEAVE";
+    if (newState.channel.id === player.voiceChannel && !newState.member.user.bot) stateChange.type = "JOIN";
+  }
+  // double triggered on purpose for MOVE events
+  if (stateChange.type === "JOIN") stateChange.channel = newState.channel;
+  if (stateChange.type === "LEAVE") stateChange.channel = oldState.channel;
 
-    // move check first as it changes type
-    if (stateChange.type === "MOVE") {
-        if (oldState.channel.id === player.voiceChannel) stateChange.type = "LEAVE";
-        if (newState.channel.id === player.voiceChannel) stateChange.type = "JOIN";
-    }
-    // double triggered on purpose for MOVE events
-    if (stateChange.type === "JOIN") stateChange.channel = newState.channel;
-    if (stateChange.type === "LEAVE") stateChange.channel = oldState.channel;
+  // check if the bot's voice channel is involved (return otherwise)
+  if (!stateChange.channel || stateChange.channel.id !== player.voiceChannel)
+    return;
 
-    // check if the bot's voice channel is involved (return otherwise)
-    if (!stateChange.channel || stateChange.channel.id !== player.voiceChannel) return;
+  // filter current users based on being a bot
+  stateChange.members = stateChange.channel.members.filter(
+    (member) => !member.user.bot
+  );  
+  
+  switch (stateChange.type) {
+    case "JOIN":
+      if (stateChange.members.size === 1 && player.paused) {
+        let emb = new MessageEmbed()
+          .setAuthor(`Resuming paused queue`, client.botconfig.IconURL)
+          .setColor(client.botconfig.EmbedColor)
+          .setDescription(
+            `Resuming playback because all of you left me with music to play all alone`
+          );
+        await client.channels.cache.get(player.textChannel).send(emb);
 
-    // filter current users based on being a bot
-    stateChange.members = stateChange.channel.members.filter(member => !member.user.bot);
+        // update the now playing message and bring it to the front
+        let msg2 = await client.channels.cache
+          .get(player.textChannel)
+          .send(player.nowPlayingMessage.embeds[0]);
+        player.setNowplayingMessage(msg2);
 
-    switch (stateChange.type) {
-        case "JOIN":
-            if (stateChange.members.size === 1 && player.paused) {
-                let emb = new MessageEmbed()
-                    .setAuthor(`Resuming paused queue`, client.botconfig.IconURL)
-                    .setColor("RANDOM")
-                    .setDescription(`Resuming playback because all of you left me with music to play all alone`);
-                await client.channels.cache.get(player.textChannel).send(emb);
+        player.pause(false);
+      }
+      break;
+    case "LEAVE":
+      if (stateChange.members.size === 0 && !player.paused && player.playing) {
+        player.pause(true);
 
-                // update the now playing message and bring it to the front
-                let msg2 = await client.channels.cache.get(player.textChannel).send(player.nowPlayingMessage.embeds[0])
-                player.setNowplayingMessage(msg2);
+        let emb = new MessageEmbed()
+          .setAuthor(`Paused!`, client.botconfig.IconURL)
+          .setColor(client.botconfig.EmbedColor)
+          .setDescription(`The player has been paused because everybody left.`);
+        await client.channels.cache.get(player.textChannel).send(emb);
+      }
+      if (stateChange.members.size > 0) {
+        player.destroy(true);
 
-                player.pause(false);
-            }
-            break;
-        case "LEAVE":
-            if (stateChange.members.size === 0 && !player.paused && player.playing) {
-                player.pause(true);
-
-                let emb = new MessageEmbed()
-                    .setAuthor(`Paused!`, client.botconfig.IconURL)
-                    .setColor(client.botconfig.EmbedColor)
-                    .setDescription(`The player has been paused because everybody left`);
-                await client.channels.cache.get(player.textChannel).send(emb);
-            }
-            break;
-    }
-}
+        let emb = new MessageEmbed()
+        .setAuthor(`Disconnected!`, client.botconfig.IconURL)
+        .setColor(client.botconfig.EmbedColor)
+        .setDescription(`The player has been paused because the bot has been kicked.`);
+      await client.channels.cache.get(player.textChannel).send(emb);      }
+      break;
+  }
+};


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
If the bot got disconnected without using the proper command the bot wouldn't be in the voice chat, but the player still existed.
You could fix this by doing !disconnect, but this is a better solution.
I have properly tested this.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
