### PR TITLE
Fix Disconnect on !play

### DIFF
--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -78,7 +78,7 @@ module.exports = async (client, oldState, newState) => {
           .setDescription(`The player has been paused because everybody left.`);
         await client.channels.cache.get(player.textChannel).send(emb);
       }
-      if (stateChange.members.size > 0) {
+      if (stateChange.members.size > 0 && player.paused) {
         player.destroy(true);
 
         let emb = new MessageEmbed()


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
If you force disconnect the bot while it was playing, it would destroy the player.
But after that, if you played something again it would destroy the player once more, well now that's fixed.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
-->
