### PR TITLE
Fixed `move.js` not accepting 1 as a valid track or position.

### DIFF
--- a/commands/slash/move.js
+++ b/commands/slash/move.js
@@ -51,12 +51,12 @@ const command = new SlashCommand()
     }
 
     let trackNum = Number(track) - 1;
-    if (trackNum < 1 || trackNum > player.queue.length - 1) {
+    if (trackNum < 0 || trackNum > player.queue.length - 1) {
       return interaction.reply(":x: | **Invalid track number**");
     }
 
     let dest = Number(position) - 1;
-    if (dest < 1 || dest > player.queue.length - 1) {
+    if (dest < 0 || dest > player.queue.length - 1) {
       return interaction.reply(":x: | **Invalid position number**");
     }
 


### PR DESCRIPTION
It fixes the command not accepting 1 as track number or position number. Caused due to oversight where user inputted number was reduced by 1 hence reducing the minimum valid value for the variable as 0 and not 1.

I do not know Javascript, but I do know basic math and logic :)
Fixes #767