### PR TITLE
Updated permission integer

### DIFF
--- a/config.js
+++ b/config.js
@@ -8,7 +8,7 @@ module.exports = {
   defaultVolume: 100, //Sets the default volume of the bot, You can change this number anywhere from 1 to 100
   supportServer: "https://discord.gg/sbySMS7m3v", //Support Server Link
   Issues: "https://github.com/SudhanPlayz/Discord-MusicBot/issues", //Bug Report Link
-  permissions: 826839002433, //Bot Inviting Permissions
+  permissions: 277083450689, //Bot Inviting Permissions
   disconnectTime: 30000, //How long should the bot wait before disconnecting from the voice channel. in miliseconds. set to 1 for instant disconnect.
   alwaysplay: true, // when set to true music will always play no matter if theres no one in voice channel.
   debug: false, //Debug mode


### PR DESCRIPTION
The original permission integer is now invalid since Discord changed how the values are summed. 

The new integer corresponds to the same set of permissions as the old integer with one extra permission which I think might be useful in the future "Allow use of External Emojis"