### PR TITLE
Lyrics Pagination

### DIFF
--- a/commands/slash/lyrics.js
+++ b/commands/slash/lyrics.js
@@ -14,46 +14,97 @@ const command = new SlashCommand()
       .setRequired(false)
   )
   .setRun(async (client, interaction, options) => {
-    await interaction.reply({
-      embeds: [client.Embed(":mag_right: **Searching...**")],
-    });
-
-    const args = interaction.options.getString("song");
-
-    let player = client.manager.players.get(interaction.guild.id);
-
-    if (!args && !player)
-      return interaction.editReply({
-        embeds: [client.ErrorEmbed("**There's nothing playing**")],
-      });
-
-    // if no input, search for the current song. if no song console.log("No song input");
-    let search = args ? args : player.queue.current.title;
-    let url = `https://api.darrennathanael.com/lyrics?song=${search}`;
-    
-    
-    // get the lyrics 
-    let lyrics = await fetch(url).then((res) => res.json());
-	  let text = lyrics.lyrics;
-	if(text.length > 4096){
-		text = text.substring(0, 4090) + '...';
+	await interaction.deferReply().catch((_) => {});
+	
+	await interaction.editReply({
+		embeds: [client.Embed(":mag_right: **Searching...**")],
+	});
+	
+	const args = interaction.options.getString("song");
+	
+	let player = client.manager.players.get(interaction.guild.id);
+	
+	if (!args && !player)
+	return interaction.editReply({
+		embeds: [client.ErrorEmbed("❌ | **There's nothing playing**")],
+	});
+	
+	// if no input, search for the current song. if no song console.log("No song input");
+	let search = args ? args : player.queue.current.title;
+	let url = `https://api.darrennathanael.com/lyrics?song=${search}`;
+	
+	
+	// get the lyrics 
+	let lyrics = await fetch(url).then((res) => res.json());
+	
+	// if the status is not ok then send error embed and return	
+	if (lyrics.response !== 200) {
+		let failEmbed = new MessageEmbed()
+		.setColor("RED")
+		.setDescription(`❌ | No lyrics found for ${search}! Please try again.`);
+		return interaction.editReply({ embeds: [failEmbed] });
 	}
+	
+	let text = lyrics.lyrics;
+	
+	// check for pagination, if needed construct appropriate components, initialize first string to displate on page [0]
+	if(text.length > 4090){
+		text = text.substring(0, 4090) + "...";
+		let lyricsEmbed = new MessageEmbed()
+			.setColor(client.config.embedColor)
+			.setTitle(`${lyrics.full_title}`)
+			.setURL(lyrics.url)
+			.setThumbnail(lyrics.thumbnail)
+			.setDescription(text);
 
-    // if the status is ok then send the embed
-    if (lyrics.response == 200) {
-      let lyricsEmbed = new MessageEmbed()
-        .setColor(client.config.embedColor)
-        .setTitle(`${lyrics.full_title}`)
-        .setURL(lyrics.url)
-        .setThumbnail(lyrics.thumbnail)
-        .setDescription(text);
-      return interaction.editReply({ embeds: [lyricsEmbed] });
-    } else if (lyrics.response !== 200) {
-      let failEmbed = new MessageEmbed()
-        .setColor("RED")
-        .setDescription(`❌ | No lyrics found for ${search}! Please try again.`);
-      return interaction.editReply({ embeds: [failEmbed] });
-    }
-  });
+		let maxPages = Math.ceil(lyrics.lyrics.length / 4090);
 
-module.exports = command;
+		
+		// default page
+		let pageNo = 0;
+		
+		
+		// Construction of the buttons for the embed in case pagination is needed
+		const getButtons = (pageNo) => {
+			return new MessageActionRow().addComponents(
+				new MessageButton()
+				.setCustomId("lyrics_pag_but_2_app")
+				.setEmoji("◀️")
+				.setStyle("PRIMARY")
+				.setDisabled(pageNo == 0),
+				new MessageButton()
+				.setCustomId("lyrics_pag_but_1_app")
+				.setEmoji("▶️")
+				.setStyle("PRIMARY")
+				.setDisabled(pageNo == (maxPages - 1)),
+			);
+		};
+
+		const tempMsg = await interaction.editReply({ embeds: [lyricsEmbed], components: [getButtons(pageNo)], fetchReply: true });
+		const collector = tempMsg.createMessageComponentCollector({ time: 600000, componentType: "BUTTON" });
+	
+		collector.on("collect", async (iter) => {
+			if (iter.customId === "lyrics_pag_but_1_app") {
+				pageNo++;
+			} else if (iter.customId === "lyrics_pag_but_2_app") {
+				pageNo--;
+			}
+			
+			text = lyrics.lyrics.substring(pageNo * 4090, (pageNo * 4090) + 4090);
+			
+			lyricsEmbed.setDescription(text);
+			
+			await iter.update({ embeds: [lyricsEmbed], components: [getButtons(pageNo)], fetchReply: true });
+		});
+	} else {
+		return interaction.editReply({embeds: [new MessageEmbed()
+			.setColor(client.config.embedColor)
+			.setTitle(`${lyrics.full_title}`)
+			.setURL(lyrics.url)
+			.setThumbnail(lyrics.thumbnail)
+			.setDescription(text)
+		]});
+	}
+});
+
+module.exports = command;	


### PR DESCRIPTION
Implemented the suggestion from DarrenOfficial of making the lyrics paginated if they exceed 4096 characters in length

**Please describe the changes this PR makes and why it should be merged:**
The update to the command allows for the lyrics to never be cut off. Instead a pagination system is implemented to preserve the integrity of the lyrics and allow users to scroll through the pages of the lyrics.
**Status and versioning classification:**
Finished; v5/commands/slash/lyrics.js
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
