### PR TITLE
Change errorEmbed to embed msg to remove double ❌

### DIFF
--- a/commands/slash/lyrics.js
+++ b/commands/slash/lyrics.js
@@ -26,7 +26,7 @@ const command = new SlashCommand()
 	
 	if (!args && !player)
 	return interaction.editReply({
-		embeds: [client.ErrorEmbed("❌ | **There's nothing playing**")],
+		embeds: [client.Embed("❌ | **There's nothing playing**")],
 	});
 	
 	// if no input, search for the current song. if no song console.log("No song input");


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
There are double ❌ when there includes ErrorEmbed and ❌
**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
-->