### PR TITLE
fix: Double ❌ in lyrics and loop command 

### DIFF
--- a/commands/slash/loop.js
+++ b/commands/slash/loop.js
@@ -8,7 +8,7 @@ const command = new SlashCommand()
     let player = client.manager.players.get(interaction.guild.id);
     if (!player) {
       return interaction.reply({
-        embeds: [client.ErrorEmbed("❌ | **Nothing is playing right now...**")],
+        embeds: [client.ErrorEmbed("**Nothing is playing right now...**")],
       });
     }
     if (!interaction.member.voice.channel) {

--- a/commands/slash/lyrics.js
+++ b/commands/slash/lyrics.js
@@ -26,7 +26,7 @@ const command = new SlashCommand()
 	
 	if (!args && !player)
 	return interaction.editReply({
-		embeds: [client.Embed("❌ | **There's nothing playing**")],
+		embeds: [client.ErrorEmbed("**There's nothing playing**")],
 	});
 	
 	// if no input, search for the current song. if no song console.log("No song input");


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
lyrics.js and loop.js had an extra "❌ |" causing the bot to show it twice as ErrorEmbed already has one.