### PR TITLE
fix to hanging login on replit systems

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,15 @@
 const DiscordMusicBot = require("./structures/DiscordMusicBot");
+const { exec } = require("child_process");
 const client = new DiscordMusicBot();
+
+if (process.env.REPL_ID) {
+	console.log("Replit system detected, initiating special `unhandledRejection` event listener")
+	process.on('unhandledRejection', (reason, promise) => {
+		promise.catch((err) => {
+			if (err.status === 429) { exec("kill 1") }
+		});
+	}); 
+}
 
 client.build();
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR brings a fix to the common 429 response on some replit systems when having the bot log in

**Status and versioning classification:**
It's only been tested on the v5 as of now, but the mechanic is the same, should work globally and modularly in any part of the program that is pre-loaded before logging in.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
