### PR TITLE
Avoid repeating sequence of tracks

### DIFF
--- a/commands/slash/autoplay.js
+++ b/commands/slash/autoplay.js
@@ -56,6 +56,7 @@ const command = new SlashCommand()
         if (a && !psba.includes(a)) psba.push(a);
       }
       if (r) player.queue.add(r);
+      while (psba.length > 100) psba.shift();
       player.set("autoplayed", psba);
 
       let embed = new MessageEmbed()

--- a/commands/slash/autoplay.js
+++ b/commands/slash/autoplay.js
@@ -42,7 +42,7 @@ const command = new SlashCommand()
 
     const autoplay = player.get("autoplay");
 
-    if (autoplay === false) {
+    if (autoplay !== true) {
       const identifier = player.queue.current.identifier;
 
       player.set("autoplay", true);
@@ -50,7 +50,13 @@ const command = new SlashCommand()
       player.set("identifier", identifier);
       const search = `https://www.youtube.com/watch?v=${identifier}&list=RD${identifier}`;
       res = await player.search(search, interaction.user);
-      player.queue.add(res.tracks[1]);
+      const psba = player.get("autoplayed") || [];
+      const r = res.tracks[1];
+      for (const a of [identifier, r?.identifier]) {
+        if (a && !psba.includes(a)) psba.push(a);
+      }
+      if (r) player.queue.add(r);
+      player.set("autoplayed", psba);
 
       let embed = new MessageEmbed()
         .setColor(client.config.embedColor)

--- a/commands/slash/play.js
+++ b/commands/slash/play.js
@@ -77,7 +77,18 @@ const command = new SlashCommand()
     }
 
     if (res.loadType === "TRACK_LOADED" || res.loadType === "SEARCH_RESULT") {
-      player.queue.add(res.tracks[0]);
+        const r = res.tracks[0];
+        if (player.get("autoplay")) {
+        const psba = player.get("autoplayed") || [];
+        if (r) {
+          if (!psba.includes(r?.identifier)) {
+            psba.push(r.identifier);
+          }
+        }
+        while (psba.length > 100) psba.shift();
+        player.set("autoplayed", psba);
+      }
+      player.queue.add(r);
       if (!player.playing && !player.paused && !player.queue.size)
         player.play();
       let addQueueEmbed = client
@@ -117,6 +128,16 @@ const command = new SlashCommand()
     }
 
     if (res.loadType === "PLAYLIST_LOADED") {
+      if (player.get("autoplay")) {
+        const psba = player.get("autoplayed") || [];
+        for (const r of res.tracks) {
+          if (r && !psba.includes(r?.identifier)) {
+            psba.push(r.identifier);
+          }
+        }
+        while (psba.length > 100) psba.shift();
+        player.set("autoplayed", psba);
+      }
       player.queue.add(res.tracks);
       if (
         !player.playing &&

--- a/lib/DiscordMusicBot.js
+++ b/lib/DiscordMusicBot.js
@@ -118,7 +118,6 @@ class DiscordMusicBot extends Client {
       nodes: this.config.nodes,
       retryDelay: this.config.retryDelay,
       retryAmount: this.config.retryAmount,
-      autoPlay: true,
       clientName: `DiscordMusic/v${require("../package.json").version} (Bot: ${
         this.config.clientId
       })`,
@@ -279,12 +278,38 @@ class DiscordMusicBot extends Client {
       .on("trackEnd", async (player, track, playload) => {
         const autoplay = player.get("autoplay");
         if (autoplay === true) {
+          /**
+           * Array of played songs
+           * @type {string[]}
+           */
+          const psba = player.get("autoplayed") || [];
+
           const requester = player.get("requester");
           const oldidentifier = player.get("identifier");
           const identifier = player.queue.current.identifier;
           const search = `https://www.youtube.com/watch?v=${identifier}&list=RD${identifier}`;
           res = await player.search(search, requester);
-          player.queue.add(res.tracks[2]);
+
+          /**
+           * Track to add to queue
+           * @type {import("erela.js").Track}
+           */
+          let a;
+          for (let i = 0; i < res.tracks.length; i++) {
+            const v = res.tracks[i];
+
+            // Don't add this track if it's the last 100 played
+            if (!v || psba.includes(v.identifier)) continue;
+
+            a = v;
+            psba.push(a.identifier);
+            break;
+          }
+          if (!a) throw new RangeError("End of playlist");
+          player.queue.add(a);
+          
+          if (psba.length > 100) psba.shift();
+          player.set("autoplayed", psba);
         }
       })
       .on("queueEnd", (player) => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Sometimes when the `autoplay` mode is enabled, it plays an already played track and then goes back to the previously played track. This happens because Youtube algorithm for their autoplay feature returns a finite number of track in the specific identifier in the URL used to get the next track to play in autoplay mode.

Say, based on the current code track `A` can points to track `B`, but then track `B` can points back to track `A` and it's an infinite loop, OR track `A` is the at end of the playlist, which in that case it will just play that one single track over and over again.

This change fixes that by checking if the next track is on the last 100 recently played track in the guild for that specific session. There's one caveat, if there's no more different track returned by Youtube outside of the recorded 100 track on the played list, eg. user never add new different track which will change the route of Youtube autoplay algorithm to the queue, it will just end the session. Any suggestion are very welcomed.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
