### PR TITLE
dashboard [v5]

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "prettier --check .",
     "deploy": "node deploy/global",
     "guild": "node deploy/guild",
-    "ddev": "cd dashboard && npm run dev",
+    "dev": "cd dashboard && npm run dev",
     "dbuild": "cd dashboard && npm run build && npm run export",
     "dstart": "cd dashboard && npm run start",
     "postinstall": "cd dashboard && curl --compressed -o- -L https://yarnpkg.com/install.sh | bash && yarn"


### PR DESCRIPTION
its `npm run dev` or `yarn dev` if refer to the dashboard wiki but in package.json its `ddev`.