### PR TITLE
Add module.exports to invite.js

### DIFF
--- a/commands/slash/invite.js
+++ b/commands/slash/invite.js
@@ -17,3 +17,4 @@ const command = new SlashCommand()
         ]
     });
 });
+module.exports = command;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The invite.js was missing `module.exports = command;` due to which the command was loading.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating