### PR TITLE
fix: Error in invite link

### DIFF
--- a/commands/slash/invite.js
+++ b/commands/slash/invite.js
@@ -13,7 +13,7 @@ const command = new SlashCommand()
             .addComponents(new MessageButton()
             .setLabel("Invite me")
             .setStyle("LINK")
-            .setURL(`https://discord.com/oauth2/authorize?client_id=${client.config.clientId}&permissions=${client.config.permissions}&scope=${client.config.scopes.toString().replace(',', '%20')}`))
+            .setURL(`https://discord.com/oauth2/authorize?client_id=${client.config.clientId}&permissions=${client.config.permissions}&scope=${client.config.scopes.toString().replace(/,/g, '%20')}`))
         ]
     });
 });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the issue (#888) causing the invite.js to not replace all ',' in `invite.js`. A global .replace() should be used so that it replaces all `,` with `%20`

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating