### PR TITLE
fix: bot disconnecting if the queue is empty and 247 command is run

### DIFF
--- a/commands/slash/247.js
+++ b/commands/slash/247.js
@@ -58,10 +58,11 @@ const command = new SlashCommand()
       }`
     );
 
-    if (!player.playing && player.queue.totalSize === 0) player.destroy();
+    if (!player.playing && player.queue.totalSize === 0 && twentyFourSeven) player.destroy();
 
     return interaction.reply({ embeds: [twentyFourSevenEmbed] });
   });
+
 module.exports = command;
 // check above message, it is a little bit confusing. and erros are not handled. probably should be fixed.
 // ok use catch ez kom  follow meh ;_;
@@ -69,3 +70,4 @@ module.exports = command;
 // play commanddddd, if timeout or takes 1000 years to find song it crashed
 // OKIE, leave the comment here for idk
 // Comment very useful, 247 good :+1:
+// twentyFourSeven = best;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the issue that causes the bot to disconnect when the /247 command is run and the queue is empty regardless if 24/7 is enabled or not.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
