### PR TITLE
fix queue.js

### DIFF
--- a/commands/slash/queue.js
+++ b/commands/slash/queue.js
@@ -47,11 +47,14 @@ const command = new SlashCommand()
       let song = player.queue.current;
       const embed = new MessageEmbed()
         .setColor(client.config.embedColor)
-        .setDescription(`**♪ | Now playing:** [${song.title}](${song.uri})`)
+        .setDescription(
+          `**♪ | Now playing:** [${song.title}](${song.uri})` || "No Title") 
         .addFields(
           {
             name: "Duration",
-            value: `\`${pms(player.position, { colonNotation: true })} / ${pms(
+            value: song.isStream
+            ? `\`LIVE\``
+            : `\`${pms(player.position, { colonNotation: true })} / ${pms(
               player.queue.current.duration,
               { colonNotation: true }
             )}\``,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
When playing a single stream, command "queue" shows wrong duration. Also added check in case if title does not exist