### PR TITLE
Add dotenv to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "discord-api-types": "0.33.5",
     "discord-together": "^1.3.25",
     "discord.js": "^13.8.0",
+    "dotenv": "^16.0.1",
     "ejs": "^3.1.6",
     "erela.js": "^2.3.3",
     "erela.js-deezer": "^1.0.7",


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Added dotenv in package.json which was causing the error `Cannot find module 'dotenv'`
5c96f16 [`#902`](https://github.com/SudhanPlayz/Discord-MusicBot/pull/902)

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating