### PR TITLE
fix queue.js

### DIFF
--- a/commands/slash/queue.js
+++ b/commands/slash/queue.js
@@ -51,8 +51,10 @@ const command = new SlashCommand()
         .addFields(
           {
             name: "Duration",
-            value: `\`${pms(player.position, { colonNotation: true })} / ${pms(
-              player.queue.current.duration,
+            value: song.isStream
+              ? `\`стрім\``
+              : `\`${pms(player.position, { colonNotation: true })} / ${pms(
+                player.queue.current.duration,
               { colonNotation: true }
             )}\``,
             inline: true,
@@ -96,9 +98,10 @@ const command = new SlashCommand()
           .addFields(
             {
               name: "Track Duration",
-              value: `\`${pms(player.position, {
-                colonNotation: true,
-              })} / ${pms(player.queue.current.duration, {
+              value: song.isStream
+                ? `\`стрім\``
+                : `\`${pms(player.position, { colonNotation: true })} / ${pms(
+                  player.queue.current.duration, {
                 colonNotation: true,
               })}\``,
               inline: true,
@@ -136,9 +139,10 @@ const command = new SlashCommand()
           .addFields(
             {
               name: "Track Duration",
-              value: `\`${pms(player.position, {
-                colonNotation: true,
-              })} / ${pms(player.queue.current.duration, {
+              value: song.isStream
+                ? `\`стрім\``
+                : `\`${pms(player.position, { colonNotation: true })} / ${pms(
+                  player.queue.current.duration, {
                 colonNotation: true,
               })}\``,
               inline: true,
@@ -207,9 +211,10 @@ const command = new SlashCommand()
               .addFields(
                 {
                   name: "Track Duration",
-                  value: `\`${pms(player.position, {
-                    colonNotation: true,
-                  })} / ${pms(player.queue.current.duration, {
+                  value: song.isStream
+                    ? `\`стрім\``
+                    : `\`${pms(player.position, { colonNotation: true })} / ${pms(
+                      player.queue.current.duration, {
                     colonNotation: true,
                   })}\``,
                   inline: true,
@@ -250,9 +255,10 @@ const command = new SlashCommand()
               .addFields(
                 {
                   name: "Track Duration",
-                  value: `\`${pms(player.position, {
-                    colonNotation: true,
-                  })} / ${pms(player.queue.current.duration, {
+                  value: song.isStream
+                    ? `\`стрім\``
+                    : `\`${pms(player.position, { colonNotation: true })} / ${pms(
+                      player.queue.current.duration, {
                     colonNotation: true,
                   })}\``,
                   inline: true,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When playing a stream, the command "queue" shows the wrong duration. Update from #903

I must say, that exists else one problem. If the stream is in the queue with at least else one track, then `pms(player.queue.duration)`, which shows "Total Tracks Duration", breaks and displays some crazy number, like `292471208:247:08:36:30`. I don`t have a solution to this problem yet. Tested on https://www.youtube.com/watch?v=5qap5aO4i9A

