### PR TITLE
feat: Flip flop switch for resume/pause events (the continuation)

### DIFF
--- a/config.js
+++ b/config.js
@@ -12,7 +12,7 @@ module.exports = {
   Issues: "https://github.com/SudhanPlayz/Discord-MusicBot/issues", //Bug Report Link
   permissions: 277083450689, //Bot Inviting Permissions
   disconnectTime: 30000, //How long should the bot wait before disconnecting from the voice channel. in miliseconds. set to 1 for instant disconnect.
-  alwaysplay: true, // when set to true music will always play no matter if theres no one in voice channel.
+  alwaysplay: false, // when set to true music will always play no matter if theres no one in voice channel.
   debug: false, //Debug mode
   // Lavalink server; optional public lavalink -> https://lavalink-list.darrennathanael.com/
   // The default one should work fine.

--- a/events/messageDelete.js
+++ b/events/messageDelete.js
@@ -1,0 +1,11 @@
+/**
+ * On messageDelete events, adds the message to a WeakSet within the bot's client
+ * allowing for the bot to easily see which messages have been deleted asynchronously
+ * during the run time of the bot
+ * @param {Client} client
+ * @param {Message} message
+ */
+
+module.exports = async (client, message) => {
+  if (!client.isMessageDeleted(message)) client.markMessageAsDeleted(message);
+};

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -1,4 +1,4 @@
-const { MessageEmbed } = require('discord.js');
+const { MessageEmbed } = require("discord.js");
 
 /**
  *
@@ -25,9 +25,17 @@ module.exports = async (client, oldState, newState) => {
   if (oldState.channel !== null && newState.channel !== null)
     stateChange.type = "MOVE";
   if (oldState.channel === null && newState.channel === null) return; // you never know, right
-  if (newState.serverMute == true && oldState.serverMute == false && newState.id === client.config.clientId)
+  if (
+    newState.serverMute == true &&
+    oldState.serverMute == false &&
+    newState.id === client.config.clientId
+  )
     return player.pause(true);
-  if (newState.serverMute == false && oldState.serverMute == true && newState.id === client.config.clientId)
+  if (
+    newState.serverMute == false &&
+    oldState.serverMute == true &&
+    newState.id === client.config.clientId
+  )
     return player.pause(false);
   // move check first as it changes type
   if (stateChange.type === "MOVE") {
@@ -49,31 +57,31 @@ module.exports = async (client, oldState, newState) => {
 
   switch (stateChange.type) {
     case "JOIN":
-		if (client.config.alwaysplay === false) {
-			if (stateChange.members.size === 1 && player.paused) {
-				player.pause(false);
-				let playerResumed = new MessageEmbed()
-				.setColor(client.config.embedColor)
-				.setTitle(`Resumed!`, client.config.iconURL)
-				.setDescription(
-					`Playing  [${player.queue.current.title}](${player.queue.current.uri})`
-					)
-					.setFooter({ text: `The current song has been resumed.` });
-					
+      if (client.config.alwaysplay === false) {
+        if (stateChange.members.size === 1 && player.paused) {
+          player.pause(false);
+          let playerResumed = new MessageEmbed()
+            .setColor(client.config.embedColor)
+            .setTitle(`Resumed!`, client.config.iconURL)
+            .setDescription(
+              `Playing  [${player.queue.current.title}](${player.queue.current.uri})`
+            )
+            .setFooter({ text: `The current song has been resumed.` });
+
           let resumeMessage = await client.channels.cache
             .get(player.textChannel)
             .send({ embeds: [playerResumed] });
-			player.setResumeMessage(client, resumeMessage);
-			
-			setTimeout(() => {
-				if (!client.isMessageDeleted(resumeMessage)) {
-					resumeMessage.delete();
-					client.markMessageAsDeleted(resumeMessage);
-				}
-			}, 5000);
+          player.setResumeMessage(client, resumeMessage);
+
+          setTimeout(() => {
+            if (!client.isMessageDeleted(resumeMessage)) {
+              resumeMessage.delete();
+              client.markMessageAsDeleted(resumeMessage);
+            }
+          }, 5000);
         }
-	}
-	break;
+      }
+      break;
     case "LEAVE":
       if (client.config.alwaysplay === false) {
         if (

--- a/lib/DiscordMusicBot.js
+++ b/lib/DiscordMusicBot.js
@@ -290,7 +290,7 @@ class DiscordMusicBot extends Client {
             components: [client.createController(player.options.guild)],
           })
           .catch(this.warn);
-        player.setNowplayingMessage(nowPlaying);
+        player.setNowplayingMessage(client, nowPlaying);
       })
 
       .on("queueEnd", async (player, track) => {

--- a/lib/DiscordMusicBot.js
+++ b/lib/DiscordMusicBot.js
@@ -62,6 +62,7 @@ class DiscordMusicBot extends Client {
 
     this.database = new jsoning("db.json");
 
+    this.deletedMessages = new WeakSet;
     this.getLavalink = getLavalink;
     this.getChannel = getChannel;
     this.ms = prettyMilliseconds;
@@ -380,6 +381,24 @@ class DiscordMusicBot extends Client {
           }
         }
       });
+  }
+
+  /**
+   * Checks if a message has been deleted during the run time of the Bot
+   * @param {Message} message
+   * @returns
+   */
+  isMessageDeleted(message) {
+    return this.deletedMessages.has(message);
+  }
+
+  /**
+   * Marks (adds) a message on the client's `deletedMessages` WeakSet so it's
+   * state can be seen through the code
+   * @param {Message} message
+   */
+  markMessageAsDeleted(message) {
+    this.deletedMessages.add(message);
   }
 
   /**

--- a/lib/EpicPlayer.js
+++ b/lib/EpicPlayer.js
@@ -11,13 +11,44 @@ Structure.extend(
       }
 
       /**
-       * Sets now playing message for deleting next time
+       * Set's (maps) the client's resume message so it can be deleted afterwards
+       * @param {Client} client
        * @param {Message} message
+       * @returns the Set Message
        */
-      setNowplayingMessage(message) {
-        if (this.nowPlayingMessage && !this.nowPlayingMessage.deleted)
-          //Message#Deleted is deprecated soon
+      setResumeMessage(client, message) {
+        if (this.pausedMessage && !client.isMessageDeleted(this.pausedMessage)) {
+          this.pausedMessage.delete();
+          client.markMessageAsDeleted(this.pausedMessage);
+        }
+        return (this.resumeMessage = message);
+      }
+
+      /**
+       * Set's (maps) the client's paused message so it can be deleted afterwards
+       * @param {Client} client
+       * @param {Message} message
+       * @returns
+       */
+      setPausedMessage(client, message) {
+        if (this.resumeMessage && !client.isMessageDeleted(this.resumeMessage)) {
+          this.resumeMessage.delete();
+          client.markMessageAsDeleted(this.resumeMessage);
+        }
+        return (this.pausedMessage = message);
+      }
+
+      /**
+       * Set's (maps) the client's now playing message so it can be deleted afterwards
+       * @param {Client} client
+       * @param {Message} message
+       * @returns
+       */
+      setNowplayingMessage(client, message) {
+        if (this.nowPlayingMessage && !client.isMessageDeleted(this.nowPlayingMessage)) {
           this.nowPlayingMessage.delete();
+          client.markMessageAsDeleted(this.nowPlayingMessage);
+        }
         return (this.nowPlayingMessage = message);
       }
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Continuation of [#912](https://github.com/SudhanPlayz/Discord-MusicBot/pull/912)

Requested by a fellow member of the discord server, thinking it was a good idea to reduce the clutter which could be made in chats as one might frequently enter and exit a VC, this feat automatically deletes old messages regarding this matter.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
