### PR TITLE
fix: deprecated default properties

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -69,6 +69,8 @@ class Server extends EventEmitter {
 
     // Session and Passport
     this.app.use(session({
+      resave: true,
+      saveUninitialized: true,
       secret: client.config.cookieSecret,
       cookie: {
         secure: client.config.website.startsWith("https://"),


### PR DESCRIPTION


**Please describe the changes this PR makes and why it should be merged:**
Fixed the deprecation messages showing up in console due to the unsafe nature of uninitialized constant default properties in the express-session:
```
express-session deprecated undefined resave option; provide resave option api\index.js:71:18
express-session deprecated undefined saveUninitialized option; provide saveUninitialized option api\index.js:71:18
```
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
