### PR TITLE
fix: Cannot find module 'node:events' for lower node version

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,2 @@
-run = "node index.js"
+run = "npx node index.js"
 language = "NodeJS"


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR is a temporary workaround for the issue mentioned in #940 causing replit to not upgrade to node16 and showing the error `Error: Cannot find module 'node:events'` while running the [`master`](https://github.com/SudhanPlayz/Discord-MusicBot/tree/master) branch of the bot.
