### PR TITLE
4

### DIFF
--- a/commands/slash/previous.js
+++ b/commands/slash/previous.js
@@ -31,19 +31,25 @@ const command = new SlashCommand()
       });
     }
 
-    let previousSong = player.queue.previous;
+    const previousSong = player.queue.previous;
+    const currentSong = player.queue.current;
+    const nextSong = player.queue[0]
 
-    if (!previousSong)
+    if (!previousSong
+      || previousSong === currentSong
+      || previousSong === nextSong) {
       return interaction.reply({
         embeds: [
           new MessageEmbed()
             .setColor("RED")
             .setDescription("There is no previous song in the queue."),
         ],
-      });
+      })}
 
-    const currentSong = player.queue.current;
-    player.play(previousSong);
+    if (previousSong !== currentSong && previousSong !== nextSong) {
+      player.queue.splice(0, 0, currentSong)
+      player.play(previousSong);
+    }
     interaction.reply({
       embeds: [
         new MessageEmbed()
@@ -53,8 +59,6 @@ const command = new SlashCommand()
           ),
       ],
     });
-
-    previousSong = currentSong;
   });
 
 module.exports = command;

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "guild": "node deploy/guild",
     "ddev": "cd dashboard && npm run dev",
     "dbuild": "cd dashboard && npm run build && npm run export",
-    "dstart": "cd dashboard && npm run start",
-    "postinstall": "cd dashboard && curl --compressed -o- -L https://yarnpkg.com/install.sh | bash && yarn"
+    "dstart": "cd dashboard && npm run start"
   },
   "repository": {
     "type": "git",

--- a/util/Controller.js
+++ b/util/Controller.js
@@ -45,7 +45,7 @@ module.exports = async (client, interaction) => {
     player.queue.clear();
     player.stop();
     client.warn(`Player: ${player.options.guild} | Successfully stopped the player`);
-    const msg = await interaction.channel.send({
+    await interaction.reply({
       embeds: [
         client.Embed(
             "⏹️ | **Successfully stopped the player**"
@@ -53,7 +53,7 @@ module.exports = async (client, interaction) => {
       ],
     });
     setTimeout(() => {
-      msg.delete();
+      interaction.deleteReply();
     }, 5000);
 
     interaction.update({
@@ -65,24 +65,35 @@ module.exports = async (client, interaction) => {
 
   // if theres no previous song, return an error.
   if (property === "Replay") {
-    if (!player.queue.previous) {
-      const msg = await interaction.channel.send({
-        embeds: [client.Embed("❌ | **There is no previous song to replay.**")],
+    const previousSong = player.queue.previous;
+    const currentSong = player.queue.current;
+    const nextSong = player.queue[0]
+
+    if (!previousSong
+      || previousSong === currentSong
+      || previousSong === nextSong) {
+      await interaction.reply({
+        embeds: [
+          new MessageEmbed()
+          .setColor("RED")
+          .setDescription("There is no previous song in the queue."),
+        ],
       });
       setTimeout(() => {
-        msg.delete();
+        interaction.deleteReply();
       }, 5000);
       return;
     }
-    const currentSong = player.queue.current;
-    player.play(player.queue.previous);
-    if (currentSong) player.queue.unshift(currentSong);
-    return;
+    if (previousSong !== currentSong && previousSong !== nextSong) {
+      player.queue.splice(0, 0, currentSong)
+      player.play(previousSong);
+      return;
+    }
   }
 
   if (property === "PlayAndPause") {
     if (!player || (!player.playing && player.queue.totalSize === 0)) {
-      const msg = await interaction.channel.send({
+      await interaction.reply({
         embeds: [
           new MessageEmbed()
               .setColor("RED")
@@ -90,7 +101,7 @@ module.exports = async (client, interaction) => {
         ],
       });
       setTimeout(() => {
-        msg.delete();
+        interaction.deleteReply();
       }, 5000);
 
     } else {


### PR DESCRIPTION
## Please describe the changes this PR makes and why it should be merged:

When a player is created, object Queue already contains `player.queue.previous` and it is identical to `player.queue.current'. Related bugs:

* every time the button "Replay" is pressed, a copy of current playing song is added to the queue. Here I played a single song and pressed "Replay" button 2 times:

* If a queue of few tracks plays and `player.queue.current !== player.queue.previous`,  when using `/previous`, current and perious tracks start rotating so it could be a situation, when after using command `/previous` playing order instead of __previous->current->next1->next2__  is __previous->next1->next2__

* If a queue of few tracks plays and `player.queue.current !== player.queue.previous`,  when pressing the button "Replay", a copy of current playing song is still added to the queue. Original queue:

After I pressed "Replay" button 3 times:


## After this commit
A single song, pressed "Replay" button:


Also as you could have seen on "After" screenshots, current implementation of deleting messages after timeout throws errors, so I want to revert this change
