### PR TITLE
fix kickstartReplit.sh: botconfig.js doesn't exist in v5

### DIFF
--- a/kickstartReplit.sh
+++ b/kickstartReplit.sh
@@ -1,5 +1,5 @@
 echo Kickstarting replit
-echo Please make sure to fill your botconfig.js before running this script
+echo Please make sure to fill config.js before running this script
 npm i
 npm run deploy
 node index.js


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Small change: `botconfig.js` -> `config.js`,
since botconfig.js doesn't exist in v5