### PR TITLE
New command: /autopause - toggles automatically pausing the player when everyone leaves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ dev-config.js
 db.json
 yarn.lock
 package-lock.json
+.idea/

--- a/commands/slash/247.js
+++ b/commands/slash/247.js
@@ -45,10 +45,11 @@ const command = new SlashCommand()
 		} else {
 			player.set("twentyFourSeven", false);
 		}
-		
-		twentyFourSevenEmbed.setDescription(
-			`✅ | **24/7 mode is \`${ !twentyFourSeven? "ON" : "OFF" }\`**`,
-		);
+		twentyFourSevenEmbed
+		  .setDescription(`**24/7 mode is** \`${!twentyFourSeven ? "ON" : "OFF"}\``)
+		  .setFooter({
+		    text: `The bot will ${!twentyFourSeven ? "now" : "no longer"} stay connected to the voice channel 24/7.`
+      });
 		client.warn(
 			`Player: ${ player.options.guild } | [${ colors.blue(
 				"24/7",

--- a/commands/slash/autopause.js
+++ b/commands/slash/autopause.js
@@ -1,0 +1,62 @@
+const colors = require("colors");
+const { MessageEmbed } = require("discord.js");
+const SlashCommand = require("../../lib/SlashCommand");
+
+const command = new SlashCommand()
+  .setName("autopause")
+  .setDescription("Automatically pause when everyone leaves the voice channel (toggle)")
+  .setRun(async (client, interaction) => {
+    let channel = await client.getChannel(client, interaction);
+    if (!channel) return;
+
+    let player;
+    if (client.manager)
+      player = client.manager.players.get(interaction.guild.id);
+    else
+      return interaction.reply({
+        embeds: [
+          new MessageEmbed()
+            .setColor("RED")
+            .setDescription("Lavalink node is not connected"),
+        ],
+      });
+
+    if (!player) {
+      return interaction.reply({
+        embeds: [
+          new MessageEmbed()
+            .setColor("RED")
+            .setDescription("There's nothing playing in the queue"),
+        ],
+        ephemeral: true,
+      });
+    }
+
+    let embed = new MessageEmbed().setColor(client.config.embedColor);
+    const autoPause = player.get("autoPause");
+    player.set("requester", interaction.guild.me);
+
+    if (!autoPause || autoPause === false) {
+      player.set("autoPause", true);
+    } else {
+      player.set("autoPause", false);
+    }
+    embed
+			.setDescription(`**Auto Pause is** \`${!autoPause ? "ON" : "OFF"}\``)
+			.setFooter({
+              text: `The player will ${!autoPause ? "now be automatically" : "no longer be"} paused when everyone leaves the voice channel.`,
+            });
+    client.warn(
+      `Player: ${player.options.guild} | [${colors.blue(
+        "AUTOPAUSE"
+      )}] has been [${colors.blue(!autoPause ? "ENABLED" : "DISABLED")}] in ${
+        client.guilds.cache.get(player.options.guild)
+          ? client.guilds.cache.get(player.options.guild).name
+          : "a guild"
+      }`
+    );
+
+    return interaction.reply({ embeds: [embed] });
+  });
+
+module.exports = command;

--- a/commands/slash/autopause.js
+++ b/commands/slash/autopause.js
@@ -44,8 +44,8 @@ const command = new SlashCommand()
     embed
 			.setDescription(`**Auto Pause is** \`${!autoPause ? "ON" : "OFF"}\``)
 			.setFooter({
-              text: `The player will ${!autoPause ? "now be automatically" : "no longer be"} paused when everyone leaves the voice channel.`,
-            });
+			  text: `The player will ${!autoPause ? "now be automatically" : "no longer be"} paused when everyone leaves the voice channel.`
+			});
     client.warn(
       `Player: ${player.options.guild} | [${colors.blue(
         "AUTOPAUSE"

--- a/commands/slash/autoqueue.js
+++ b/commands/slash/autoqueue.js
@@ -44,7 +44,11 @@ const command = new SlashCommand()
 		} else {
 			player.set("autoQueue", false);
 		}
-		embed.setDescription(`Auto Queue is \`${ !autoQueue? "ON" : "OFF" }\``);
+		embed
+		  .setDescription(`**Auto Queue is** \`${!autoQueue ? "ON" : "OFF"}\``)
+		  .setFooter({
+		    text: `Related music will ${!autoQueue ? "now be automatically" : "no longer be"} added to the queue.`
+      });
 		client.warn(
 			`Player: ${ player.options.guild } | [${ colors.blue(
 				"AUTOQUEUE",

--- a/config.js
+++ b/config.js
@@ -14,7 +14,7 @@ module.exports = {
 	disconnectTime: 30000, //- How long should the bot wait before disconnecting from the voice channel (in miliseconds). Set to 1 for instant disconnect.
 	twentyFourSeven: false, //- When set to true, the bot will never disconnect from the voice channel
 	autoQueue: false, //- When set to true, related songs will automatically be added to the queue
-	alwaysplay: false, //- When set to true, music will always play no matter if theres no one in voice channel
+	autoPause: true, //- When set to true, music will automatically be paused if everyone leaves the voice channel
 	debug: false, //- Debug mode
 	cookieSecret: "CodingWithSudhan is epic", //- Cookie Secret
 	website: "http://localhost:4200", //- without the / at the end

--- a/config.js
+++ b/config.js
@@ -12,6 +12,8 @@ module.exports = {
 	Issues: "https://github.com/SudhanPlayz/Discord-MusicBot/issues", //- Bug Report Link
 	permissions: 277083450689, //- Bot Inviting Permissions
 	disconnectTime: 30000, //- How long should the bot wait before disconnecting from the voice channel (in miliseconds). Set to 1 for instant disconnect.
+	twentyFourSeven: false, //- When set to true, the bot will never disconnect from the voice channel
+	autoQueue: false, //- When set to true, related songs will automatically be added to the queue
 	alwaysplay: false, //- When set to true, music will always play no matter if theres no one in voice channel
 	debug: false, //- Debug mode
 	cookieSecret: "CodingWithSudhan is epic", //- Cookie Secret

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -74,7 +74,7 @@ module.exports = async (client, oldState, newState) => {
 	
 	switch (stateChange.type) {
 		case "JOIN":
-			if (client.config.alwaysplay === false) {
+			if (player.get("autoPause") === true) {
 				if (player.members === 1 && player.paused && player.prevMembers != player.members) {
 					player.pause(false);
 					let playerResumed = new MessageEmbed()
@@ -100,7 +100,7 @@ module.exports = async (client, oldState, newState) => {
 			}
 			break;
 		case "LEAVE":
-			if (client.config.alwaysplay === false) {
+			if (player.get("autoPause") === true) {
 				if (
 					player.members === 0 &&
 					!player.paused &&

--- a/lib/DiscordMusicBot.js
+++ b/lib/DiscordMusicBot.js
@@ -233,15 +233,17 @@ class DiscordMusicBot extends Client {
 					return undefined;
 				}
 			})
-			.on("playerCreate", (player) => 
+			.on("playerCreate", (player) => {
+                player.set("twentyFourSeven", client.config.twentyFourSeven);
+                player.set("autoQueue", client.config.autoQueue);
 				this.warn(
 					`Player: ${ player.options.guild
 					} | A wild player has been created in ${ client.guilds.cache.get(player.options.guild)
 						? client.guilds.cache.get(player.options.guild).name
 						: "a guild"
 					}`,
-			),
-		)
+			    ),
+		    })
 			.on("playerDestroy", (player) =>
 				this.warn(
 					`Player: ${ player.options.guild

--- a/lib/DiscordMusicBot.js
+++ b/lib/DiscordMusicBot.js
@@ -236,6 +236,7 @@ class DiscordMusicBot extends Client {
 			.on("playerCreate", (player) => {
                 player.set("twentyFourSeven", client.config.twentyFourSeven);
                 player.set("autoQueue", client.config.autoQueue);
+                player.set("autoPause", client.config.autoPause);
 				this.warn(
 					`Player: ${ player.options.guild
 					} | A wild player has been created in ${ client.guilds.cache.get(player.options.guild)

--- a/lib/DiscordMusicBot.js
+++ b/lib/DiscordMusicBot.js
@@ -242,7 +242,7 @@ class DiscordMusicBot extends Client {
 						? client.guilds.cache.get(player.options.guild).name
 						: "a guild"
 					}`,
-			    ),
+			    )
 		    })
 			.on("playerDestroy", (player) =>
 				this.warn(


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- 2e85509881519cc69178eec79f9934eab945daf1 - Revert #973 (A temporary fix by @JotaroKujo0525)
Added idea folder to `.gitignore`.
- b6bfaa3e8a0ccdda7c1f247d4d51c63d28100e00 - Fix #969 (Error in [DiscordMusicBot.js](https://github.com/SudhanPlayz/Discord-MusicBot/blob/5396bedfd4466fe16cc68d7749b449c8951bc8e4/lib/DiscordMusicBot.js#L246))
https://github.com/SudhanPlayz/Discord-MusicBot/blob/5396bedfd4466fe16cc68d7749b449c8951bc8e4/lib/DiscordMusicBot.js#L246
- 3bb561faaaad81a8cc7c465fb682ad6adc80149f - Add `/autopause` command to toggle automatically pausing the player when everyone leaves the voice channel.
- e3f471e57587943bd2e69bd833632ee81b55f77d - Improve the look of `/247`, `/autopause`, and `/autoqueue` commands.
Here is a screenshot showing the new look of the aforesaid commands.
![Screenshot](https://user-images.githubusercontent.com/84950599/177664163-c9a1f74d-ec1e-4f58-a31c-b83df403eb88.png)

**Status and versioning classification:**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating