### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "colors": "^1.4.0",
     "cpu-stat": "^2.0.1",
-    "discord.js": "^12.5.3",
+    "discord.js": "12.5.3",
     "discordjs-activity": "1.4.1",
     "dotenv": "^16.0.1",
     "erela.js": "^2.3.2",


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When having "discord.js": "^12.5.3" in package.json npm will install discord.js@13.8.1. This will break the bot. That is why "discord.js": "12.5.3" would be better.