### PR TITLE
fix issues in replit v5

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,2 @@
-run = "node index.js"
+run = "bash ./kickstartReplit.sh"
 language = "Nix"

--- a/kickstartReplit.sh
+++ b/kickstartReplit.sh
@@ -1,5 +1,15 @@
 echo Kickstarting replit
 echo Please make sure to fill config.js before running this script
+if [ -d "$XDG_CONFIG_HOME/nvm" ]; then
+export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 npm i
-npm run deploy
+node index
+else
+wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
+nvm install 16
+npm i
 node index.js
+fi

--- a/replit.nix
+++ b/replit.nix
@@ -1,6 +1,5 @@
 { pkgs }: {
 	deps = [
-		pkgs.nodejs-16_x
-                pkgs.nodePackages.npm
+		pkgs.wget
 	];
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
this commit fixes the issue of the node version problem in replit containers. the error includes the `Failed to renew spotify token` and many more, this fix uses nvm to correct the node and npm versions

Steps to install:
1. Install a blank repl
2. Run this command `rm .replit replit.nix README.md; rm -rf .cache && git clone -b v5 https://github.com/jotarokujo0525/discord-musicbot .` ( to be changed to sudhanplayz/discord-musicbot when this is pushed)
3. fill your config
4. run `bash ./kickstartReplit.sh`