### PR TITLE
Using replit.nix instead of downloading nvm

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,2 @@
 run = "bash ./kickstartReplit.sh"
-language = "Nix"
+language = "Bash"

--- a/config.js
+++ b/config.js
@@ -23,9 +23,9 @@ module.exports = {
 	nodes: [
 		{
 			identifier: "Main Node", //- Used for indentifier in stats commands.
-			host: "116.202.85.52", //- The host name or IP of the lavalink server.
-			port: 25726, // The port that lavalink is listening to. This must be a number!
-			password: "animex3", //- The password of the lavalink server.
+			host: "", //- The host name or IP of the lavalink server.
+			port: 80, // The port that lavalink is listening to. This must be a number!
+			password: "", //- The password of the lavalink server.
 			retryAmount: 200, //- The amount of times to retry connecting to the node if connection got dropped.
 			retryDelay: 40, //- Delay between reconnect attempts if connection is lost.
 			secure: false, //- Can be either true or false. Only use true if ssl is enabled!

--- a/config.js
+++ b/config.js
@@ -23,9 +23,9 @@ module.exports = {
 	nodes: [
 		{
 			identifier: "Main Node", //- Used for indentifier in stats commands.
-			host: "", //- The host name or IP of the lavalink server.
-			port: 80, // The port that lavalink is listening to. This must be a number!
-			password: "", //- The password of the lavalink server.
+			host: "116.202.85.52", //- The host name or IP of the lavalink server.
+			port: 25726, // The port that lavalink is listening to. This must be a number!
+			password: "animex3", //- The password of the lavalink server.
 			retryAmount: 200, //- The amount of times to retry connecting to the node if connection got dropped.
 			retryDelay: 40, //- Delay between reconnect attempts if connection is lost.
 			secure: false, //- Can be either true or false. Only use true if ssl is enabled!

--- a/kickstartReplit.sh
+++ b/kickstartReplit.sh
@@ -1,15 +1,6 @@
 echo Kickstarting replit
 echo Please make sure to fill config.js before running this script
-if [ -d "$XDG_CONFIG_HOME/nvm" ]; then
-export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 npm i
-node index
-else
-wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
-export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
-nvm install 16
-npm i
+npm run deploy
 node index.js
 fi

--- a/kickstartReplit.sh
+++ b/kickstartReplit.sh
@@ -3,4 +3,3 @@ echo Please make sure to fill config.js before running this script
 npm i
 npm run deploy
 node index.js
-fi

--- a/replit.nix
+++ b/replit.nix
@@ -1,6 +1,6 @@
 { pkgs }: {
 	deps = [
 		pkgs.wget
-    		pkgs.nodejs-16_x
+    		pkgs.nodejs-16_x.out
 	];
 }

--- a/replit.nix
+++ b/replit.nix
@@ -1,5 +1,6 @@
 { pkgs }: {
 	deps = [
 		pkgs.wget
+    		pkgs.nodejs_16x
 	];
 }

--- a/replit.nix
+++ b/replit.nix
@@ -1,6 +1,6 @@
 { pkgs }: {
 	deps = [
 		pkgs.wget
-    		pkgs.nodejs_16x
+    		pkgs.nodejs-16_x
 	];
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The replit.nix environment is more effective and less-consuming repl storage instead of downloading nvm and install nodejs 16 from it.

Steps to produce:
1. Create new repl and Import from Github
2. Use https://github.com/ItzCuteAkemi/Discord-MusicBot as repository
3. go into version control and change from master to v5
4. fill config.js
5. type `node -v` to see the node version
6. ??
7. then run `bash ./kickstartReplit.sh` to configure the bot

Results:
![Screenshot_2022-08-01_23-01-23](https://user-images.githubusercontent.com/91181632/182191258-c337e642-90c8-454c-9620-9c424938abe2.png)

Don't mind cdf5f0b since it's dead lavalink. Just remove them if this is merged