### PR TITLE
fixed "Live" text emoji

### DIFF
--- a/commands/slash/play.js
+++ b/commands/slash/play.js
@@ -117,7 +117,7 @@ const command = new SlashCommand()
           {
             name: "Duration",
             value: res.tracks[0].isStream
-              ? `\`LIVE :red_circle: \``
+              ? `\`LIVE 🔴 \``
               : `\`${client.ms(res.tracks[0].duration, {
                   colonNotation: true,
                   secondsDecimalDigits: 0,


### PR DESCRIPTION
On DisCord the formatting was "`LIVE :red_circle:`" instead of "`LIVE 🔴`"