### PR TITLE
update node version for v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "git+https://github.com/SudhanPlayz/Discord-MusicBot.git"
   },
   "engines": {
-    "node": "^16.x"
+    "node": ">=16.x <=16.16"
   },
   "keywords": [
     "discord",


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

 The bot throws this error on Node.js 16.17: `SyntaxError: Unexpected token  in JSON at position 0`
Due to the current configuration of package.json, for example, Heroku tries to use the most recent 16 version of Node.js (16.17), on which the bot doesn`t work. As a temporary or permanent solution, I propose to set the upper limit to 16.16 (the bot still works on this version)

