### PR TITLE
Song Titles are not escaping formatting Fix, AutoPause Fix and AutoQueue on Skip Function Support

### DIFF
--- a/commands/slash/nowplaying.js
+++ b/commands/slash/nowplaying.js
@@ -49,8 +49,8 @@ const command = new SlashCommand()
 		
 		const song = player.queue.current;
         var title = escapeMarkdown(song.title)
-        var title = title.replace(/\]/g," ")
-        var title = title.replace(/\[/g," ")
+        var title = title.replace(/\]/g,"")
+        var title = title.replace(/\[/g,"")
 		const embed = new MessageEmbed()
 			.setColor(client.config.embedColor)
 			.setAuthor({ name: "Now Playing", iconURL: client.config.iconURL })

--- a/commands/slash/nowplaying.js
+++ b/commands/slash/nowplaying.js
@@ -1,4 +1,5 @@
 const { MessageEmbed } = require("discord.js");
+const escapeMarkdown = require('discord.js').Util.escapeMarkdown;
 const SlashCommand = require("../../lib/SlashCommand");
 const prettyMilliseconds = require("pretty-ms");
 
@@ -47,6 +48,9 @@ const command = new SlashCommand()
 		}
 		
 		const song = player.queue.current;
+        var title = escapeMarkdown(song.title)
+        var title = title.replace(/\]/g," ")
+        var title = title.replace(/\[/g," ")
 		const embed = new MessageEmbed()
 			.setColor(client.config.embedColor)
 			.setAuthor({ name: "Now Playing", iconURL: client.config.iconURL })
@@ -73,7 +77,7 @@ const command = new SlashCommand()
 			// show the thumbnail of the song using displayThumbnail("maxresdefault")
 			.setThumbnail(song.displayThumbnail("maxresdefault"))
 			// show the title of the song and link to it
-			.setDescription(`[${ song.title }](${ song.uri })`);
+			.setDescription(`[${ title }](${ song.uri })`);
 		return interaction.reply({ embeds: [embed] });
 	});
 module.exports = command;

--- a/commands/slash/play.js
+++ b/commands/slash/play.js
@@ -102,8 +102,8 @@ const command = new SlashCommand()
         player.play();
       }
       var title = escapeMarkdown(res.tracks[0].title)
-      var title = title.replace(/\]/g," ")
-      var title = title.replace(/\[/g," ")
+      var title = title.replace(/\]/g,"")
+      var title = title.replace(/\[/g,"")
       let addQueueEmbed = new MessageEmbed()
         .setColor(client.config.embedColor)
         .setAuthor({ name: "Added to queue", iconURL: client.config.iconURL })

--- a/commands/slash/play.js
+++ b/commands/slash/play.js
@@ -1,10 +1,11 @@
 const SlashCommand = require("../../lib/SlashCommand");
 const { MessageEmbed } = require("discord.js");
+const escapeMarkdown = require('discord.js').Util.escapeMarkdown;
 
 const command = new SlashCommand()
   .setName("play")
   .setDescription(
-    "Searches and plays the requested song\n__Supports:__\nYoutube, Spotify, Deezer, Apple Music"
+    "Searches and plays the requested song \nSupports: \nYoutube, Spotify, Deezer, Apple Music"
   )
   .addStringOption((option) =>
     option
@@ -100,12 +101,14 @@ const command = new SlashCommand()
       if (!player.playing && !player.paused && !player.queue.size) {
         player.play();
       }
-
+      var title = escapeMarkdown(res.tracks[0].title)
+      var title = title.replace(/\]/g," ")
+      var title = title.replace(/\[/g," ")
       let addQueueEmbed = new MessageEmbed()
         .setColor(client.config.embedColor)
         .setAuthor({ name: "Added to queue", iconURL: client.config.iconURL })
         .setDescription(
-          `[${res.tracks[0].title}](${res.tracks[0].uri})` || "No Title"
+          `[${title}](${res.tracks[0].uri})` || "No Title"
         )
         .setURL(res.tracks[0].uri)
         .addFields(

--- a/commands/slash/queue.js
+++ b/commands/slash/queue.js
@@ -1,5 +1,6 @@
 const SlashCommand = require("../../lib/SlashCommand");
 const { MessageEmbed, MessageButton, MessageActionRow } = require("discord.js");
+const escapeMarkdown = require('discord.js').Util.escapeMarkdown;
 const load = require("lodash");
 const pms = require("pretty-ms");
 
@@ -46,12 +47,16 @@ const command = new SlashCommand()
 		
 		await interaction.deferReply().catch(() => {
 		});
+        
 		
 		if (!player.queue.size || player.queue.size === 0) {
-			let song = player.queue.current;
+            let song = player.queue.current;
+            var title = escapeMarkdown(song.title)
+            var title = title.replace(/\]/g," ")
+            var title = title.replace(/\[/g," ")
 			const queueEmbed = new MessageEmbed()
 				.setColor(client.config.embedColor)
-				.setDescription(`**♪ | Now playing:** [${ song.title }](${ song.uri })`)
+				.setDescription(`**♪ | Now playing:** [${ title }](${ song.uri })`)
 				.addFields(
 					{
 						name: "Duration",
@@ -111,11 +116,14 @@ const command = new SlashCommand()
 			}
 			
 			if (player.queue.size < 11 || player.queue.totalSize < 11) {
-				let song = player.queue.current;
+                let song = player.queue.current;
+                var title = escapeMarkdown(song.title)
+                var title = title.replace(/\]/g," ")
+                var title = title.replace(/\[/g," ")
 				const embedTwo = new MessageEmbed()
 					.setColor(client.config.embedColor)
 					.setDescription(
-						`**♪ | Now playing:** [${ song.title }](${ song.uri }) [${ player.queue.current.requester }]\n\n**Queued Tracks**\n${ pages[page] }`,
+						`**♪ | Now playing:** [${ title }](${ song.uri }) [${ player.queue.current.requester }]\n\n**Queued Tracks**\n${ pages[page] }`,
 					)
 					.addFields(
 						{
@@ -154,10 +162,13 @@ const command = new SlashCommand()
 					});
 			} else {
 				let song = player.queue.current;
+                var title = escapeMarkdown(song.title)
+                var title = title.replace(/\]/g," ")
+                var title = title.replace(/\[/g," ")
 				const embedThree = new MessageEmbed()
 					.setColor(client.config.embedColor)
 					.setDescription(
-						`**♪ | Now playing:** [${ song.title }](${ song.uri }) [${ player.queue.current.requester }]\n\n**Queued Tracks**\n${ pages[page] }`,
+						`**♪ | Now playing:** [${ title }](${ song.uri }) [${ player.queue.current.requester }]\n\n**Queued Tracks**\n${ pages[page] }`,
 					)
 					.addFields(
 						{
@@ -230,11 +241,14 @@ const command = new SlashCommand()
 						await button.deferUpdate().catch(() => {
 						});
 						page = page + 1 < pages.length? ++page : 0;
-						
+                        let song = player.queue.current;
+                        var title = escapeMarkdown(song.title)
+                        var title = title.replace(/\]/g," ")
+                        var title = title.replace(/\[/g," ")
 						const embedFour = new MessageEmbed()
 							.setColor(client.config.embedColor)
 							.setDescription(
-								`**♪ | Now playing:** [${ song.title }](${ song.uri }) [${ player.queue.current.requester }]\n\n**Queued Tracks**\n${ pages[page] }`,
+								`**♪ | Now playing:** [${ title }](${ song.uri }) [${ player.queue.current.requester }]\n\n**Queued Tracks**\n${ pages[page] }`,
 							)
 							.addFields(
 								{
@@ -275,11 +289,14 @@ const command = new SlashCommand()
 						await button.deferUpdate().catch(() => {
 						});
 						page = page > 0? --page : pages.length - 1;
-						
+                        let song = player.queue.current;
+                        var title = escapeMarkdown(song.title)
+                        var title = title.replace(/\]/g," ")
+                        var title = title.replace(/\[/g," ")
 						const embedFive = new MessageEmbed()
 							.setColor(client.config.embedColor)
 							.setDescription(
-								`**♪ | Now playing:** [${ song.title }](${ song.uri }) [${ player.queue.current.requester }]\n\n**Queued Tracks**\n${ pages[page] }`,
+								`**♪ | Now playing:** [${ title }](${ song.uri }) [${ player.queue.current.requester }]\n\n**Queued Tracks**\n${ pages[page] }`,
 							)
 							.addFields(
 								{

--- a/commands/slash/queue.js
+++ b/commands/slash/queue.js
@@ -52,8 +52,8 @@ const command = new SlashCommand()
 		if (!player.queue.size || player.queue.size === 0) {
             let song = player.queue.current;
             var title = escapeMarkdown(song.title)
-            var title = title.replace(/\]/g," ")
-            var title = title.replace(/\[/g," ")
+            var title = title.replace(/\]/g,"")
+            var title = title.replace(/\[/g,"")
 			const queueEmbed = new MessageEmbed()
 				.setColor(client.config.embedColor)
 				.setDescription(`**♪ | Now playing:** [${ title }](${ song.uri })`)
@@ -118,8 +118,8 @@ const command = new SlashCommand()
 			if (player.queue.size < 11 || player.queue.totalSize < 11) {
                 let song = player.queue.current;
                 var title = escapeMarkdown(song.title)
-                var title = title.replace(/\]/g," ")
-                var title = title.replace(/\[/g," ")
+                var title = title.replace(/\]/g,"")
+                var title = title.replace(/\[/g,"")
 				const embedTwo = new MessageEmbed()
 					.setColor(client.config.embedColor)
 					.setDescription(
@@ -163,8 +163,8 @@ const command = new SlashCommand()
 			} else {
 				let song = player.queue.current;
                 var title = escapeMarkdown(song.title)
-                var title = title.replace(/\]/g," ")
-                var title = title.replace(/\[/g," ")
+                var title = title.replace(/\]/g,"")
+                var title = title.replace(/\[/g,"")
 				const embedThree = new MessageEmbed()
 					.setColor(client.config.embedColor)
 					.setDescription(
@@ -243,8 +243,8 @@ const command = new SlashCommand()
 						page = page + 1 < pages.length? ++page : 0;
                         let song = player.queue.current;
                         var title = escapeMarkdown(song.title)
-                        var title = title.replace(/\]/g," ")
-                        var title = title.replace(/\[/g," ")
+                        var title = title.replace(/\]/g,"")
+                        var title = title.replace(/\[/g,"")
 						const embedFour = new MessageEmbed()
 							.setColor(client.config.embedColor)
 							.setDescription(
@@ -291,8 +291,8 @@ const command = new SlashCommand()
 						page = page > 0? --page : pages.length - 1;
                         let song = player.queue.current;
                         var title = escapeMarkdown(song.title)
-                        var title = title.replace(/\]/g," ")
-                        var title = title.replace(/\[/g," ")
+                        var title = title.replace(/\]/g,"")
+                        var title = title.replace(/\[/g,"")
 						const embedFive = new MessageEmbed()
 							.setColor(client.config.embedColor)
 							.setDescription(

--- a/commands/slash/skip.js
+++ b/commands/slash/skip.js
@@ -32,9 +32,10 @@ const command = new SlashCommand()
 				],
 				ephemeral: true,
 			});
-		}
+		} 
         
-        if (player.queue[0] == undefined) {
+	        const autoQueue = player.get("autoQueue");
+                if (player.queue[0] == undefined && (!autoQueue || autoQueue === false)) {
 		return interaction.reply({
 			embeds: [
 				new MessageEmbed()

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -67,13 +67,13 @@ module.exports = async (client, oldState, newState) => {
 	if (!stateChange.channel || stateChange.channel.id !== player.voiceChannel) {
 		return;
 	}
-    player.prevMembers = player.members
-    player.members = stateChange.channel.members.filter(member => !member.user.bot).size;
+        player.prevMembers = player.members
+        player.members = stateChange.channel.members.filter(member => !member.user.bot).size;
 	switch (stateChange.type) {
 		case "JOIN":
 			if (player.get("autoPause") === true) {
-                var members = stateChange.channel.members.filter(member => !member.user.bot).size
-				if (members === 1 && player.paused && members !== player.prevMembers){
+                         var members = stateChange.channel.members.filter(member => !member.user.bot).size
+		            if (members === 1 && player.paused && members !== player.prevMembers){
 					player.pause(false);
 					let playerResumed = new MessageEmbed()
 						.setColor(client.config.embedColor)
@@ -97,11 +97,11 @@ module.exports = async (client, oldState, newState) => {
 				}
 			}
 			break;
-        case "LEAVE":
+                case "LEAVE":
 			if (player.get("autoPause") === true) {
-                var members = stateChange.channel.members.filter(member => !member.user.bot).size
-				if (members === 0 && !player.paused && player.playing){
-                    player.pause(true);
+                         var members = stateChange.channel.members.filter(member => !member.user.bot).size
+			    if (members === 0 && !player.paused && player.playing){
+                                        player.pause(true);
 					let playerPaused = new MessageEmbed()
 						.setColor(client.config.embedColor)
 						.setTitle(`Paused!`, client.config.iconURL)

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -67,12 +67,13 @@ module.exports = async (client, oldState, newState) => {
 	if (!stateChange.channel || stateChange.channel.id !== player.voiceChannel) {
 		return;
 	}
-	
+    player.prevMembers = player.members
+    player.members = stateChange.channel.members.filter(member => !member.user.bot).size;
 	switch (stateChange.type) {
 		case "JOIN":
 			if (player.get("autoPause") === true) {
-                                var members = stateChange.channel.members.filter(member => !member.user.bot).size
-				if (members === 1 && player.paused) {
+                var members = stateChange.channel.members.filter(member => !member.user.bot).size
+				if (members === 1 && player.paused && members !== player.prevMembers){
 					player.pause(false);
 					let playerResumed = new MessageEmbed()
 						.setColor(client.config.embedColor)
@@ -96,13 +97,11 @@ module.exports = async (client, oldState, newState) => {
 				}
 			}
 			break;
-		case "LEAVE":
+        case "LEAVE":
 			if (player.get("autoPause") === true) {
-                                var members = stateChange.channel.members.filter(member => !member.user.bot).size
-				if (members === 0 && !player.paused && player.playing
-				) {
-					player.pause(true);
-					
+                var members = stateChange.channel.members.filter(member => !member.user.bot).size
+				if (members === 0 && !player.paused && player.playing){
+                    player.pause(true);
 					let playerPaused = new MessageEmbed()
 						.setColor(client.config.embedColor)
 						.setTitle(`Paused!`, client.config.iconURL)

--- a/lib/DiscordMusicBot.js
+++ b/lib/DiscordMusicBot.js
@@ -172,8 +172,8 @@ class DiscordMusicBot extends Client {
         //console.log(err);
         let song = player.queue.current;
         var title = escapeMarkdown(song.title)
-        var title = title.replace(/\]/g," ")
-        var title = title.replace(/\[/g," ")
+        var title = title.replace(/\]/g,"")
+        var title = title.replace(/\[/g,"")
         
         let errorEmbed = new MessageEmbed()
           .setColor("RED")

--- a/lib/DiscordMusicBot.js
+++ b/lib/DiscordMusicBot.js
@@ -6,6 +6,7 @@ const {
   MessageActionRow,
   MessageButton,
 } = require("discord.js");
+const escapeMarkdown = require('discord.js').Util.escapeMarkdown;
 const fs = require("fs");
 const path = require("path");
 const prettyMilliseconds = require("pretty-ms");
@@ -23,7 +24,6 @@ const getChannel = require("../util/getChannel");
 const colors = require("colors");
 const filters = require("erela.js-filters");
 const { default: EpicPlayer } = require("./EpicPlayer");
-
 class DiscordMusicBot extends Client {
   /**
    * Create the music client
@@ -171,11 +171,14 @@ class DiscordMusicBot extends Client {
         );
         //console.log(err);
         let song = player.queue.current;
-
+        var title = escapeMarkdown(song.title)
+        var title = title.replace(/\]/g," ")
+        var title = title.replace(/\[/g," ")
+        
         let errorEmbed = new MessageEmbed()
           .setColor("RED")
           .setTitle("Playback error!")
-          .setDescription(`Failed to load track: \`${song.title}\``)
+          .setDescription(`Failed to load track: \`${title}\``)
           .setFooter({
             text: "Oops! something went wrong but it's not your fault!",
           });
@@ -188,11 +191,14 @@ class DiscordMusicBot extends Client {
         this.warn(`Track has an error: ${err.message}`);
         //console.log(err);
         let song = player.queue.current;
-
+        var title = escapeMarkdown(song.title)
+        var title = title.replace(/\]/g," ")
+        var title = title.replace(/\[/g," ")
+        
         let errorEmbed = new MessageEmbed()
           .setColor("RED")
           .setTitle("Track error!")
-          .setDescription(`Failed to load track: \`${song.title}\``)
+          .setDescription(`Failed to load track: \`${title}\``)
           .setFooter({
             text: "Oops! something went wrong but it's not your fault!",
           });
@@ -245,10 +251,7 @@ class DiscordMusicBot extends Client {
       })
       .on("playerDestroy", (player) =>
         this.warn(
-          `Player: ${
-            player.options.guild
-          } | A wild player has been destroyed in ${
-            client.guilds.cache.get(player.options.guild)
+          `Player: ${player.options.guild} | A wild player has been destroyed in ${client.guilds.cache.get(player.options.guild)
               ? client.guilds.cache.get(player.options.guild).name
               : "a guild"
           }`
@@ -275,11 +278,13 @@ class DiscordMusicBot extends Client {
               player.options.guild
             } | Track has been started playing [${colors.blue(track.title)}]`
           );
-
+            var title = escapeMarkdown(track.title)
+            var title = title.replace(/\]/g," ")
+            var title = title.replace(/\[/g," ")
           let trackStartedEmbed = this.Embed()
             .setAuthor({ name: "Now playing", iconURL: this.config.iconURL })
             .setDescription(
-              `[${track.title}](${track.uri})` || "No Descriptions"
+              `[${title}](${track.uri})` || "No Descriptions"
             )
             .addFields(
               {
@@ -314,7 +319,7 @@ class DiscordMusicBot extends Client {
             })
             .catch(this.warn);
           player.setNowplayingMessage(client, nowPlaying);
-        }
+       }
       )
 
       .on(
@@ -375,7 +380,7 @@ class DiscordMusicBot extends Client {
                     let disconnectedEmbed = new MessageEmbed()
                       .setColor(client.config.embedColor)
                       .setAuthor({
-                        name: "Disconnected!!",
+                        name: "Disconnected!",
                         iconURL: client.config.iconURL,
                       })
                       .setDescription(

--- a/lib/DiscordMusicBot.js
+++ b/lib/DiscordMusicBot.js
@@ -192,8 +192,8 @@ class DiscordMusicBot extends Client {
         //console.log(err);
         let song = player.queue.current;
         var title = escapeMarkdown(song.title)
-        var title = title.replace(/\]/g," ")
-        var title = title.replace(/\[/g," ")
+        var title = title.replace(/\]/g,"")
+        var title = title.replace(/\[/g,"")
         
         let errorEmbed = new MessageEmbed()
           .setColor("RED")

--- a/lib/DiscordMusicBot.js
+++ b/lib/DiscordMusicBot.js
@@ -279,8 +279,8 @@ class DiscordMusicBot extends Client {
             } | Track has been started playing [${colors.blue(track.title)}]`
           );
             var title = escapeMarkdown(track.title)
-            var title = title.replace(/\]/g," ")
-            var title = title.replace(/\[/g," ")
+            var title = title.replace(/\]/g,"")
+            var title = title.replace(/\[/g,"")
           let trackStartedEmbed = this.Embed()
             .setAuthor({ name: "Now playing", iconURL: this.config.iconURL })
             .setDescription(

--- a/util/Controller.js
+++ b/util/Controller.js
@@ -118,8 +118,9 @@ module.exports = async (client, interaction) => {
 	}
 
 	if (property === "Next") {
-     const song = player.queue.current;
-	 if (player.queue[0] == undefined) {
+                const song = player.queue.current;
+	        const autoQueue = player.get("autoQueue");
+                if (player.queue[0] == undefined && (!autoQueue || autoQueue === false)) {
 		return interaction.reply({
                         ephemeral: true,
 			embeds: [


### PR DESCRIPTION
** Please explain the changes this PR makes and why it should be combined:**

**This PR has been tested multiple times**

This PR fixes an issue where song titles were not passing formatting across different embeds and also fixes an issue where song titles could change the clickable song title link across different embeds. 
**Consequences: If a song title has "[" or "]" characters in it, those characters will be converted to "none", in other words, they will be removed.**

This PR also fixes an issue with AutoPause, so the issue is that when the player is paused and the user mutes/unmutes themselves, the player will automatically resume and that shouldn't happen.

The original issue about song titles was created [here](https://github.com/SudhanPlayz/Discord-MusicBot/issues/1070) by [MerlinDaWizard](https://github.com/MerlinDaWizard)

New on 2/11/2022, Added AutoQueue Support on Skip function #1113, so if AutoQueue is ON the song can be skipped.


**Version status and classification:**

<!-- Please move the lines that apply to you out of the comments: - The code changes have been tested against the Discord API, or there are no code changes - I know how to update the typing and have done so, or the typing does not need to be updated - This PR changes the library interface (methods or parameters added) - This PR includes breaking changes (methods removed or renamed, parameters moved or removed) - This PR **only** includes non-code changes, such as changes to the documentation, README, etc. -->

- This PR includes breaking changes (method removed or renamed, parameter moved or removed) 
- I know how to update the typing and have done so, or the typing does not need to be updated
- The code changes have been tested against the Discord API, or there are no code changes