### PR TITLE
Edited previous pull request (new link variation)

### DIFF
--- a/commands/play.js
+++ b/commands/play.js
@@ -124,6 +124,31 @@ module.exports = {
           );
         }
       } else {
+           if(SearchString.indexOf("?list=")!=-1){
+                    if(SearchString.indexOf("youtu.be")!=-1) {
+                        var cutpoint = SearchString.indexOf("?list=");
+                        SearchString = SearchString.substring(17,cutpoint)
+                        var originallink = "https://www.youtube.com/watch?v="+ SearchString.toString();
+                        SearchString=originallink;
+                        console.log(SearchString);
+                    }
+                   
+
+                   
+    
+                } else if (SearchString.indexOf("&list=") !=-1){
+                   
+                    if(SearchString.indexOf("&list=")!=-1){
+                        var cutpoint = SearchString.search("&list=");
+                        SearchString = SearchString.substring(0,cutpoint)
+                    }else {
+                        SearchString;
+                    }
+                
+
+                }else {
+                    SearchString;
+                }
         let Searched = await player.search(SearchString, message.author);
         if (!player)
           return client.sendTime(


### PR DESCRIPTION
!!!(Added new link variation)
Fix for Youtube search to find links from custom playlist For example; (https://www.youtube.com/watch?v=XgGxt76YP8A&list=WL&index=2) a link from hidden playlist looks like this and player cannot run it The original link of the song is obtained by removing the, ( &list=) part and the player can now play this song



<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
