### PR TITLE
Update DiscordMusicBot.js - Fixes bot breaking after force disconnect 

### DIFF
--- a/lib/DiscordMusicBot.js
+++ b/lib/DiscordMusicBot.js
@@ -321,7 +321,21 @@ class DiscordMusicBot extends Client {
           player.setNowplayingMessage(client, nowPlaying);
        }
       )
-
+    
+      .on(
+        "playerDisconnect",
+          /** @param {EpicPlayer} */ async (player) => {
+            if (player.twentyFourSeven) {
+              player.queue.clear();
+              player.stop();
+              player.set("autoQueue", false);
+            } else {
+              player.destroy();
+            }
+            player.setNowplayingMessage(client, null);
+          }
+      )
+    
       .on(
         "queueEnd",
         /** @param {EpicPlayer} */ async (player, track) => {


### PR DESCRIPTION
fixes the issue where when you forcefully disconnect the bot and then try to play something again, the bot breaks. It destroys the player on force disconnect so it doesn't believe it's still playing something.

**Status and versioning classification:**
 Code changes have been tested against the Discord API, or there are no code changes
 I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
-
- 
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
