### PR TITLE
fix the Now Playing message not deleting

### DIFF
--- a/lib/DiscordMusicBot.js
+++ b/lib/DiscordMusicBot.js
@@ -249,14 +249,15 @@ class DiscordMusicBot extends Client {
           }`
         );
       })
-      .on("playerDestroy", (player) =>
+      .on("playerDestroy", (player) => {
         this.warn(
           `Player: ${player.options.guild} | A wild player has been destroyed in ${client.guilds.cache.get(player.options.guild)
               ? client.guilds.cache.get(player.options.guild).name
               : "a guild"
           }`
         )
-      )
+        player.setNowplayingMessage(client, null);
+      })
       // on LOAD_FAILED send error message
       .on("loadFailed", (node, type, error) =>
         this.warn(
@@ -332,7 +333,6 @@ class DiscordMusicBot extends Client {
             } else {
               player.destroy();
             }
-            player.setNowplayingMessage(client, null);
           }
       )
     


### PR DESCRIPTION
the Now Playing message does not get deleted when using the /stop command. Now when a player is destroyed it will automatically remove the NowPlaying message if there is one. Also removed line 335 because that then makes it redundant on manual disconnects.

(accidentally removed the other pull request, oops)

Status and versioning classification:
Code changes have been tested against the Discord API, or there are no code changes
I know how to update typings and have done so, or typings don't need updating