### PR TITLE
feat: play in context command

### DIFF
--- a/commands/context/play.js
+++ b/commands/context/play.js
@@ -3,7 +3,7 @@ const { MessageEmbed } = require("discord.js");
 const escapeMarkdown = require('discord.js').Util.escapeMarkdown;
 
 module.exports = {
-    command: new ContextMenuCommandBuilder().setName("Play").setType(3),
+    command: new ContextMenuCommandBuilder().setName("Play Song").setType(3),
 
     /**
      * This function will handle context menu interaction

--- a/commands/context/play.js
+++ b/commands/context/play.js
@@ -1,0 +1,191 @@
+const { ContextMenuCommandBuilder } = require("@discordjs/builders");
+const { MessageEmbed } = require("discord.js");
+const escapeMarkdown = require('discord.js').Util.escapeMarkdown;
+
+module.exports = {
+    command: new ContextMenuCommandBuilder().setName("Play").setType(3),
+
+    /**
+     * This function will handle context menu interaction
+     * @param {import("../lib/DiscordMusicBot")} client
+     * @param {import("discord.js").GuildContextMenuInteraction} interaction
+     */
+    run: async (client, interaction, options) => {
+        let channel = await client.getChannel(client, interaction);
+        if (!channel) {
+            return;
+        }
+
+        let player;
+        if (client.manager) {
+            player = client.createPlayer(interaction.channel, channel);
+        } else {
+            return interaction.reply({
+                embeds: [
+                    new MessageEmbed()
+                        .setColor("RED")
+                        .setDescription("Lavalink node is not connected"),
+                ],
+            });
+        }
+
+        if (player.state !== "CONNECTED") {
+            player.connect();
+        }
+
+        if (channel.type == "GUILD_STAGE_VOICE") {
+            setTimeout(() => {
+                if (interaction.guild.me.voice.suppress == true) {
+                    try {
+                        interaction.guild.me.voice.setSuppressed(false);
+                    } catch (e) {
+                        interaction.guild.me.voice.setRequestToSpeak(true);
+                    }
+                }
+            }, 2000); // Need this because discord api is buggy asf, and without this the bot will not request to speak on a stage - Darren
+        }
+
+        const ret = await interaction.reply({
+            embeds: [
+                new MessageEmbed()
+                    .setColor(client.config.embedColor)
+                    .setDescription(":mag_right: **Searching...**"),
+            ],
+            fetchReply: true,
+        });
+
+        const query = (interaction.channel.messages.cache.get(interaction.targetId).content ?? await interaction.channel.messages.fetch(interaction.targetId));
+        let res = await player.search(query, interaction.user).catch((err) => {
+            client.error(err);
+            return {
+                loadType: "LOAD_FAILED",
+            };
+        });
+
+        if (res.loadType === "LOAD_FAILED") {
+            if (!player.queue.current) {
+                player.destroy();
+            }
+            await interaction
+                .editReply({
+                    embeds: [
+                        new MessageEmbed()
+                            .setColor("RED")
+                            .setDescription("There was an error while searching"),
+                    ],
+                })
+                .catch(this.warn);
+        }
+
+        if (res.loadType === "NO_MATCHES") {
+            if (!player.queue.current) {
+                player.destroy();
+            }
+            await interaction
+                .editReply({
+                    embeds: [
+                        new MessageEmbed()
+                            .setColor("RED")
+                            .setDescription("No results were found"),
+                    ],
+                })
+                .catch(this.warn);
+        }
+
+        if (res.loadType === "TRACK_LOADED" || res.loadType === "SEARCH_RESULT") {
+            player.queue.add(res.tracks[0]);
+
+            if (!player.playing && !player.paused && !player.queue.size) {
+                player.play();
+            }
+            var title = escapeMarkdown(res.tracks[0].title)
+            var title = title.replace(/\]/g, "")
+            var title = title.replace(/\[/g, "")
+            let addQueueEmbed = new MessageEmbed()
+                .setColor(client.config.embedColor)
+                .setAuthor({ name: "Added to queue", iconURL: client.config.iconURL })
+                .setDescription(
+                    `[${title}](${res.tracks[0].uri})` || "No Title"
+                )
+                .setURL(res.tracks[0].uri)
+                .addFields(
+                    {
+                        name: "Added by",
+                        value: `<@${interaction.user.id}>`,
+                        inline: true,
+                    },
+                    {
+                        name: "Duration",
+                        value: res.tracks[0].isStream
+                            ? `\`LIVE 🔴 \``
+                            : `\`${client.ms(res.tracks[0].duration, {
+                                colonNotation: true,
+                                secondsDecimalDigits: 0,
+                            })}\``,
+                        inline: true,
+                    }
+                );
+
+            try {
+                addQueueEmbed.setThumbnail(
+                    res.tracks[0].displayThumbnail("maxresdefault")
+                );
+            } catch (err) {
+                addQueueEmbed.setThumbnail(res.tracks[0].thumbnail);
+            }
+
+            if (player.queue.totalSize > 1) {
+                addQueueEmbed.addFields({
+                    name: "Position in queue",
+                    value: `${player.queue.size}`,
+                    inline: true,
+                });
+            } else {
+                player.queue.previous = player.queue.current;
+            }
+
+            await interaction.editReply({ embeds: [addQueueEmbed] }).catch(this.warn);
+        }
+
+        if (res.loadType === "PLAYLIST_LOADED") {
+            player.queue.add(res.tracks);
+
+            if (
+                !player.playing &&
+                !player.paused &&
+                player.queue.totalSize === res.tracks.length
+            ) {
+                player.play();
+            }
+
+            let playlistEmbed = new MessageEmbed()
+                .setColor(client.config.embedColor)
+                .setAuthor({
+                    name: "Playlist added to queue",
+                    iconURL: client.config.iconURL,
+                })
+                .setThumbnail(res.tracks[0].thumbnail)
+                .setDescription(`[${res.playlist.name}](${query})`)
+                .addFields(
+                    {
+                        name: "Enqueued",
+                        value: `\`${res.tracks.length}\` songs`,
+                        inline: true,
+                    },
+                    {
+                        name: "Playlist duration",
+                        value: `\`${client.ms(res.playlist.duration, {
+                            colonNotation: true,
+                            secondsDecimalDigits: 0,
+                        })}\``,
+                        inline: true,
+                    }
+                );
+
+            await interaction.editReply({ embeds: [playlistEmbed] }).catch(this.warn);
+        }
+
+        if (ret) setTimeout(() => ret.delete().catch(this.warn), 20000);
+        return ret;
+    }
+};


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This pr add a new context commands, it is play context. this command are pretty same as play slash but the difference is you dont have to use slash `/`. it works with both `https` and without `https` link

**Status and versioning classification:**
Node: 18.x
Discord.js: 13.8.0

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->

**Preview:**

![context-play](https://user-images.githubusercontent.com/90232327/209474632-6649d69d-fabd-423f-8cf4-c480037277aa.gif)


