### PR TITLE
update node-fetch to fix CVE-2022-0235

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "lodash": "^4.17.21",
     "moment": "^2.29.1",
     "moment-duration-format": "^2.3.2",
-    "node-fetch": "2.6.6",
+    "node-fetch": "2.6.7",
     "os": "^0.1.2",
     "passport": "^0.6.0",
     "passport-discord": "^0.1.4",


### PR DESCRIPTION
Update node-fetch to 2.6.7 to fix CVE-2022-0235
Reference: https://github.com/advisories/GHSA-r683-j2x4-v87g

**Please describe the changes this PR makes and why it should be merged:**

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
