### PR TITLE
Livestreams now show "Live" as duration

### DIFF
--- a/commands/grab.js
+++ b/commands/grab.js
@@ -1,5 +1,6 @@
 const { MessageEmbed } = require("discord.js");
 const prettyMilliseconds = require("pretty-ms");
+let d;
 
 module.exports = {
   name: "grab",
@@ -42,46 +43,47 @@ module.exports = {
         message.channel,
         "❌ | **You must be in the same voice channel as me to use this command!**"
       );
-    message.author
-      .send(
-        new MessageEmbed()
-          .setAuthor(
-            `Song saved`,
-            client.user.displayAvatarURL({
-              dynamic: true,
-            })
-          )
-          .setThumbnail(
-            `https://img.youtube.com/vi/${player.queue.current.identifier}/mqdefault.jpg`
-          )
-          .setURL(player.queue.current.uri)
-          .setColor(client.botconfig.EmbedColor)
-          .setTitle(`**${player.queue.current.title}**`)
-          .addField(
-            `⌛ Duration: `,
-            `\`${prettyMilliseconds(player.queue.current.duration, {
-              colonNotation: true,
-            })}\``,
-            true
-          )
-          .addField(`🎵 Author: `, `\`${player.queue.current.author}\``, true)
-          .addField(
-            `▶ Play it:`,
-            `\`${
-              GuildDB ? GuildDB.prefix : client.botconfig.DefaultPrefix
-            }play ${player.queue.current.uri}\``
-          )
-          .addField(`🔎 Saved in:`, `<#${message.channel.id}>`)
-          .setFooter(
-            `Requested by: ${player.queue.current.requester.tag}`,
-            player.queue.current.requester.displayAvatarURL({
-              dynamic: true,
-            })
-          )
+    let GrabEmbed = new MessageEmbed()
+      .setAuthor(
+        `Song saved`,
+        client.user.displayAvatarURL({
+          dynamic: true,
+        })
       )
-      .catch((e) => {
-        return message.channel.send("**❌ Your DMs are disabled**");
+      .setThumbnail(
+        `https://img.youtube.com/vi/${player.queue.current.identifier}/mqdefault.jpg`
+      )
+      .setURL(player.queue.current.uri)
+      .setColor(client.botconfig.EmbedColor)
+      .setTitle(`**${player.queue.current.title}**`);
+
+    // Check if duration matches duration of livestream
+
+    if (player.queue.current.duration == 9223372036854776000) {
+      d = "Live";
+    } else {
+      d = prettyMilliseconds(player.queue.current.duration, {
+        colonNotation: true,
       });
+    }
+    GrabEmbed.addField(`⌛ Duration: `, `\`${d}\``, true)
+      .addField(`🎵 Author: `, `\`${player.queue.current.author}\``, true)
+      .addField(
+        `▶ Play it:`,
+        `\`${GuildDB ? GuildDB.prefix : client.botconfig.DefaultPrefix}play ${
+          player.queue.current.uri
+        }\``
+      )
+      .addField(`🔎 Saved in:`, `<#${message.channel.id}>`)
+      .setFooter(
+        `Requested by: ${player.queue.current.requester.tag}`,
+        player.queue.current.requester.displayAvatarURL({
+          dynamic: true,
+        })
+      );
+    message.author.send(GrabEmbed).catch((e) => {
+      return message.channel.send("**❌ Your DMs are disabled**");
+    });
 
     client.sendTime(message.channel, "✅ | **Check your DMs!**");
   },
@@ -130,14 +132,16 @@ module.exports = {
           .setURL(player.queue.current.uri)
           .setColor(client.botconfig.EmbedColor)
           .setTimestamp()
-          .setTitle(`**${player.queue.current.title}**`)
-          .addField(
-            `⌛ Duration: `,
-            `\`${prettyMilliseconds(player.queue.current.duration, {
-              colonNotation: true,
-            })}\``,
-            true
-          )
+          .setTitle(`**${player.queue.current.title}**`);
+        if (player.queue.current.duration == 9223372036854776000) {
+          d = "Live";
+        } else {
+          d = prettyMilliseconds(player.queue.current.duration, {
+            colonNotation: true,
+          });
+        }
+        embed
+          .addField(`⌛ Duration: `, `\`${d}\``, true)
           .addField(`🎵 Author: `, `\`${player.queue.current.author}\``, true)
           .addField(
             `▶ Play it:`,

--- a/commands/nowplaying.js
+++ b/commands/nowplaying.js
@@ -31,7 +31,14 @@ module.exports = {
       .setColor(client.botconfig.EmbedColor)
       .setDescription(`[${song.title}](${song.uri})`)
       .addField("Requested by", `${song.requester}`, true)
-      .addField(
+      .setThumbnail(player.queue.current.displayThumbnail());
+
+    // Check if song duration matches livestream duration
+
+    if (player.queue.current.duration == 9223372036854776000) {
+      QueueEmbed.addField("Duration", "`Live`");
+    } else {
+      QueueEmbed.addField(
         "Duration",
         `${
           client.ProgressBar(player.position, player.queue.current.duration, 15)
@@ -41,8 +48,9 @@ module.exports = {
         })} / ${prettyMilliseconds(player.queue.current.duration, {
           colonNotation: true,
         })}\``
-      )
-      .setThumbnail(player.queue.current.displayThumbnail());
+      );
+    }
+
     return message.channel.send(QueueEmbed);
   },
 
@@ -68,7 +76,14 @@ module.exports = {
         .setColor(client.botconfig.EmbedColor)
         .setDescription(`[${song.title}](${song.uri})`)
         .addField("Requested by", `${song.requester}`, true)
-        .addField(
+        .setThumbnail(player.queue.current.displayThumbnail());
+
+      // Check if song duration matches livestream duration
+
+      if (player.queue.current.duration == 9223372036854776000) {
+        QueueEmbed.addField("Duration", "`Live`");
+      } else {
+        QueueEmbed.addField(
           "Duration",
           `${
             client.ProgressBar(
@@ -81,8 +96,8 @@ module.exports = {
           })} / ${prettyMilliseconds(player.queue.current.duration, {
             colonNotation: true,
           })}\``
-        )
-        .setThumbnail(player.queue.current.displayThumbnail());
+        );
+      }
       return interaction.send(QueueEmbed);
     },
   },

--- a/commands/play.js
+++ b/commands/play.js
@@ -1,6 +1,7 @@
 const { Util, MessageEmbed } = require("discord.js");
 const { TrackUtils, Player } = require("erela.js");
 const prettyMilliseconds = require("pretty-ms");
+let d;
 
 module.exports = {
   name: "play",
@@ -176,13 +177,18 @@ module.exports = {
             `[${Searched.tracks[0].title}](${Searched.tracks[0].uri})`
           );
           SongAddedEmbed.addField("Author", Searched.tracks[0].author, true);
-          SongAddedEmbed.addField(
-            "Duration",
-            `\`${prettyMilliseconds(Searched.tracks[0].duration, {
+
+          // Check if the duration matches the duration of a livestream
+          if (Searched.tracks[0].duration == 9223372036854776000) {
+            d = "Live";
+          } else {
+            d = prettyMilliseconds(Searched.tracks[0].duration, {
               colonNotation: true,
-            })}\``,
-            true
-          );
+            });
+          }
+
+          SongAddedEmbed.addField("Duration", `\`${d}\``, true);
+
           if (player.queue.totalSize > 1)
             SongAddedEmbed.addField(
               "Position in queue",
@@ -383,13 +389,16 @@ module.exports = {
               `[${res.tracks[0].title}](${res.tracks[0].uri})`
             );
             SongAddedEmbed.addField("Author", res.tracks[0].author, true);
-            SongAddedEmbed.addField(
-              "Duration",
-              `\`${prettyMilliseconds(res.tracks[0].duration, {
+            // Check if the duration matches the duration of a livestream
+            if (res.tracks[0].duration == 9223372036854776000) {
+              d = "Live";
+            } else {
+              d = prettyMilliseconds(res.tracks[0].duration, {
                 colonNotation: true,
-              })}\``,
-              true
-            );
+              });
+            }
+
+            SongAddedEmbed.addField("Duration", `\`${d}\``, true);
             if (player.queue.totalSize > 1)
               SongAddedEmbed.addField(
                 "Position in queue",

--- a/commands/queue.js
+++ b/commands/queue.js
@@ -1,6 +1,7 @@
 const { MessageEmbed } = require("discord.js");
 const _ = require("lodash");
 const prettyMilliseconds = require("pretty-ms");
+let d;
 
 module.exports = {
   name: "queue",
@@ -34,7 +35,13 @@ module.exports = {
           `[${player.queue.current.title}](${player.queue.current.uri})`
         )
         .addField("Requested by", `${player.queue.current.requester}`, true)
-        .addField(
+        .setThumbnail(player.queue.current.displayThumbnail());
+
+      // Check if the duration matches the duration of a livestream
+      if (player.queue.current.duration == 9223372036854776000) {
+        QueueEmbed.addField("Duration", `\`Live\``, true);
+      } else {
+        QueueEmbed.addField(
           "Duration",
           `${
             client.ProgressBar(
@@ -47,8 +54,9 @@ module.exports = {
           })} / ${prettyMilliseconds(player.queue.current.duration, {
             colonNotation: true,
           })}]\``
-        )
-        .setThumbnail(player.queue.current.displayThumbnail());
+        );
+      }
+
       return message.channel.send(QueueEmbed);
     }
 
@@ -60,15 +68,18 @@ module.exports = {
     let ChunkedSongs = _.chunk(Songs, 10); //How many songs to show per-page
 
     let Pages = ChunkedSongs.map((Tracks) => {
-      let SongsDescription = Tracks.map(
-        (t) =>
-          `\`${t.index + 1}.\` [${t.title}](${t.uri}) \n\`${prettyMilliseconds(
-            t.duration,
-            {
-              colonNotation: true,
-            }
-          )}\` **|** Requested by: ${t.requester}\n`
-      ).join("\n");
+      let SongsDescription = Tracks.map((t) => {
+        let d;
+        // Check if duration matches duration of livestream
+        if (t.duration == 9223372036854776000) {
+          d = "Live";
+        } else {
+          d = prettyMilliseconds(t.duration, { colonNotation: true });
+        }
+        return `\`${t.index + 1}.\` [${t.title}](${
+          t.uri
+        }) \n\`${d}\` **|** Requested by: ${t.requester}\n`;
+      }).join("\n");
 
       let Embed = new MessageEmbed()
         .setAuthor("Queue", client.botconfig.IconURL)
@@ -76,16 +87,25 @@ module.exports = {
         .setDescription(
           `**Currently Playing:** \n[${player.queue.current.title}](${player.queue.current.uri}) \n\n**Up Next:** \n${SongsDescription}\n\n`
         )
-        .addField("Total songs: \n", `\`${player.queue.totalSize - 1}\``, true)
-        .addField(
-          "Total length: \n",
-          `\`${prettyMilliseconds(player.queue.duration, {
-            colonNotation: true,
-          })}\``,
-          true
-        )
-        .addField("Requested by:", `${player.queue.current.requester}`, true)
-        .addField(
+        .addField("Total songs: \n", `\`${player.queue.totalSize - 1}\``, true);
+
+      // Check if duration matches duration of livestream
+      if (player.queue.duration >= 9223372036854776000) {
+        d = "Live";
+      } else {
+        d = prettyMilliseconds(player.queue.duration, { colonNotation: true });
+      }
+
+      Embed.addField("Total length: \n", `\`${d}\``, true).addField(
+        "Requested by:",
+        `${player.queue.current.requester}`,
+        true
+      );
+
+      if (player.queue.current.duration == 9223372036854776000) {
+        Embed.addField("Current song duration:", "`Live`");
+      } else {
+        Embed.addField(
           "Current song duration:",
           `${
             client.ProgressBar(
@@ -98,8 +118,10 @@ module.exports = {
           })} / ${prettyMilliseconds(player.queue.current.duration, {
             colonNotation: true,
           })}\``
-        )
-        .setThumbnail(player.queue.current.displayThumbnail());
+        );
+      }
+
+      Embed.setThumbnail(player.queue.current.displayThumbnail());
 
       return Embed;
     });
@@ -143,7 +165,11 @@ module.exports = {
             `[${player.queue.current.title}](${player.queue.current.uri})`
           )
           .addField("Requested by", `${player.queue.current.requester}`, true)
-          .addField(
+          .setThumbnail(player.queue.current.displayThumbnail());
+        if (player.queue.current.duration == 9223372036854776000) {
+          QueueEmbed.addField("Duration", `\`Live\``, true);
+        } else {
+          QueueEmbed.addField(
             "Duration",
             `${
               client.ProgressBar(
@@ -156,8 +182,8 @@ module.exports = {
             })} / ${prettyMilliseconds(player.queue.current.duration, {
               colonNotation: true,
             })}]\``
-          )
-          .setThumbnail(player.queue.current.displayThumbnail());
+          );
+        }
         return interaction.send(QueueEmbed);
       }
 
@@ -169,14 +195,18 @@ module.exports = {
       let ChunkedSongs = _.chunk(Songs, 10); //How many songs to show per-page
 
       let Pages = ChunkedSongs.map((Tracks) => {
-        let SongsDescription = Tracks.map(
-          (t) =>
-            `\`${t.index + 1}.\` [${t.title}](${
-              t.uri
-            }) \n\`${prettyMilliseconds(t.duration, {
-              colonNotation: true,
-            })}\` **|** Requested by: ${t.requester}\n`
-        ).join("\n");
+        let SongsDescription = Tracks.map((t) => {
+          let d;
+          // Check if duration matches duration of livestream
+          if (t.duration == 9223372036854776000) {
+            d = "Live";
+          } else {
+            d = prettyMilliseconds(t.duration, { colonNotation: true });
+          }
+          return `\`${t.index + 1}.\` [${t.title}](${
+            t.uri
+          }) \n\`${d}\` **|** Requested by: ${t.requester}\n`;
+        }).join("\n");
 
         let Embed = new MessageEmbed()
           .setAuthor("Queue", client.botconfig.IconURL)
@@ -188,16 +218,27 @@ module.exports = {
             "Total songs: \n",
             `\`${player.queue.totalSize - 1}\``,
             true
-          )
-          .addField(
-            "Total length: \n",
-            `\`${prettyMilliseconds(player.queue.duration, {
-              colonNotation: true,
-            })}\``,
-            true
-          )
-          .addField("Requested by:", `${player.queue.current.requester}`, true)
-          .addField(
+          );
+
+        // Check if duration matches duration of livestream
+        if (player.queue.duration >= 9223372036854776000) {
+          d = "Live";
+        } else {
+          d = prettyMilliseconds(player.queue.duration, {
+            colonNotation: true,
+          });
+        }
+
+        Embed.addField("Total length: \n", `\`${d}\``, true).addField(
+          "Requested by:",
+          `${player.queue.current.requester}`,
+          true
+        );
+
+        if (player.queue.current.duration == 9223372036854776000) {
+          Embed.addField("Current song duration:", "`Live`");
+        } else {
+          Embed.addField(
             "Current song duration:",
             `${
               client.ProgressBar(
@@ -205,13 +246,15 @@ module.exports = {
                 player.queue.current.duration,
                 15
               ).Bar
-            } \`[${prettyMilliseconds(player.position, {
+            } \`${prettyMilliseconds(player.position, {
               colonNotation: true,
             })} / ${prettyMilliseconds(player.queue.current.duration, {
               colonNotation: true,
-            })}]\``
-          )
-          .setThumbnail(player.queue.current.displayThumbnail());
+            })}\``
+          );
+        }
+
+        Embed.setThumbnail(player.queue.current.displayThumbnail());
 
         return Embed;
       });

--- a/structures/DiscordMusicBot.js
+++ b/structures/DiscordMusicBot.js
@@ -12,6 +12,7 @@ const prettyMilliseconds = require("pretty-ms");
 const deezer = require("erela.js-deezer");
 const apple = require("erela.js-apple");
 const facebook = require("erela.js-facebook");
+let d;
 
 //Class extending Stuff
 require("discordjs-activity"); //Epic Package, For more details: https://www.npmjs.com/package/discordjs-activity
@@ -165,14 +166,17 @@ class DiscordMusicBot extends Client {
           .setThumbnail(player.queue.current.displayThumbnail())
           .setDescription(`[${track.title}](${track.uri})`)
           .addField("Requested by", `${track.requester}`, true)
-          .addField(
-            "Duration",
-            `\`${prettyMilliseconds(track.duration, {
-              colonNotation: true,
-            })}\``,
-            true
-          )
           .setColor(this.botconfig.EmbedColor);
+
+        // Check if the duration matches the duration of a livestream
+        if (track.duration == 9223372036854776000) {
+          d = "Live";
+        } else {
+          d = prettyMilliseconds(track.duration, { colonNotation: true });
+        }
+
+        TrackStartedEmbed.addField("Duration", `\`${d}\``, true);
+
         //.setFooter("Started playing at");
         let NowPlaying = await client.channels.cache
           .get(player.textChannel)


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**Status and versioning classification:**
- This PR changes the library's interface (methods or parameters added)
- Code changes have been tested against the Discord API, or there are no code changes

Livestreams now actually display `Live` as duration rather than `292471208:247:07:12:56`
