### PR TITLE
Fix: Incorrect regex syntax causing issues with lyrics search

### DIFF
--- a/commands/slash/lyrics.js
+++ b/commands/slash/lyrics.js
@@ -54,7 +54,7 @@ const command = new SlashCommand()
 		const phrasesToRemove = [
 			"Full Video", "Full Audio", "Official Music Video", "Lyrics", "Lyrical Video",
 			"Feat.", "Ft.", "Official", "Audio", "Video", "HD", "4K", "Remix", "Lyric Video", "Lyrics Video", "8K", 
-			"High Quality", "Animation Video", "\\(Official Video\\. .*\\)", "\\(Music Video\\. .*\\)", "[NCS Release]",
+			"High Quality", "Animation Video", "\\(Official Video\\. .*\\)", "\\(Music Video\\. .*\\)", "\\[NCS Release\\]",
 			"Extended", "DJ Edit", "with Lyrics", "Lyrics", "Karaoke",
 			"Instrumental", "Live", "Acoustic", "Cover", "\\(feat\\. .*\\)"
 		];


### PR DESCRIPTION
pretty self explanatory.

before:
![image](https://github.com/SudhanPlayz/Discord-MusicBot/assets/84950599/ffa7f101-ba56-4ad1-81be-ec22a6773fa0)

after:
![image](https://github.com/SudhanPlayz/Discord-MusicBot/assets/84950599/2a65f3a5-e305-45d8-940a-1fb963209309)
