### PR TITLE
Fix passport.js logout by providing callback

### DIFF
--- a/api/routes.js
+++ b/api/routes.js
@@ -63,8 +63,15 @@ api.get("/api/commands", (req, res) => {
 });
 
 api.get("/logout", (req, res) => {
-  if (req.user) req.logout();
-  res.redirect("/");
+  if (req.user) {
+    req.logout((err) => {
+      if (err) throw err;
+
+      res.redirect("/");
+    });
+  } else {
+    res.redirect("/");
+  }
 });
 
 module.exports = api;


### PR DESCRIPTION
Passport 0.6.0 introduced a breaking change that now requires [a callback to be provided for ](https://github.com/jaredhanson/passport/blob/1e8f112bd233dbffb1904d4dd2051780d81b0a22/CHANGELOG.md) `req#logout()`. Without the callback, logging out does not work on the dashboard.

This PR adds said callback and fixes logging out.

**Status and versioning classification:**
- No code changes affect the Discord API
- Typings don't need updating
- This PR does not contain breaking changes
- I've tested this PR on my machine