### PR TITLE
fix(docker): changed lavalink image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./config.js:/usr/src/app/config.js:ro
 
   lavalink:
-    image: fredboat/lavalink:dev
+    image: ghcr.io/lavalink-devs/lavalink:3
     container_name: music-lavalink
     hostname: lavalink
     restart: unless-stopped


### PR DESCRIPTION
Since v4 is now used in the Lavalink master Github branch, the Docker Compose file no longer works.

In this PR I reset the service to the v3. The Docker Compose file can now be used again.

_Lavalink + Musicbot Service has been tested in Docker Compose enviroment_
