### PR TITLE
Fixed docker-compose lavalink with stable version, updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Build and start bot and lavalink
 docker-compose up -d --build
 ```
 ### 💪🏻 Non-Docker
-> The `config.js` file should be configured first.
+> The `config.js` file should be configured first. Don't forget to add a lavalink host
 
 Install all dependencies and deploy Slash Commands
 ```sh

--- a/README.md
+++ b/README.md
@@ -32,7 +32,25 @@ What do you gain from it? Let us explain:
 
 ## 📝 | Tutorial
 
-Soon
+### 🐳 Docker
+> The `config.js` file should be configured with the host `"lavalink"`, and you should use the same `password` as in `docker/application.yml`.
+
+Build and start bot and lavalink
+```sh
+docker-compose up -d --build
+```
+### 💪🏻 Non-Docker
+> The `config.js` file should be configured first.
+
+Install all dependencies and deploy Slash Commands
+```sh
+npm install
+npm run deploy
+```
+Start the bot
+```sh
+node index.js
+```
 
 ## 📝 | [Support Server](https://discord.gg/sbySMS7m3v)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./config.js:/usr/src/app/config.js:ro
 
   lavalink:
-    image: fredboat/lavalink:dev
+    image: fredboat/lavalink:439f122
     container_name: music-lavalink
     hostname: lavalink
     restart: unless-stopped


### PR DESCRIPTION
The docker-compose file had the dev version of lavalink, which doesn't work properly with the bot. I tested it and put version 3.7.8 into lavalink, and it's more stable than the dev version.

Tutorial added to README

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
