### PR TITLE
Connection to a self-hosted lavalink

### DIFF
--- a/config.js
+++ b/config.js
@@ -26,9 +26,9 @@ module.exports = {
 	nodes: [
 		{
 			identifier: "Main Node", //- Used for indentifier in stats commands.
-			host: "", //- The host name or IP of the lavalink server.
-			port: 80, // The port that lavalink is listening to. This must be a number!
-			password: "", //- The password of the lavalink server.
+			host: "lavalink", //- The host name or IP of the lavalink server.
+			port: 2333, // The port that lavalink is listening to. This must be a number!
+			password: "bonsoirDocker", //- The password of the lavalink server.
 			retryAmount: 200, //- The amount of times to retry connecting to the node if connection got dropped.
 			retryDelay: 40, //- Delay between reconnect attempts if connection is lost.
 			secure: false, //- Can be either true or false. Only use true if ssl is enabled!


### PR DESCRIPTION
Changed config.js to automatically connect to a lavalink from a docker-compose image.

## Please describe the changes this PR makes and why it should be merged:

Previously you had to change config.js to use a built-in lavalink node.
With this change it will be easier to setup for *not-so-geeky* users.

## Status and versioning classification:

- There are no code changes
- Typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated default settings for server connectivity to enhance user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->